### PR TITLE
feat(marketplace): make repo installable as a Claude Code marketplace + AI-native review adjustments

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,40 @@
+{
+  "name": "ai-marketplace",
+  "owner": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "metadata": {
+    "description": "AI-Native marketplace of Claude Code plugins and skills — autonomous squads, value loops, and token-saving routers.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "spotify-squad",
+      "source": "./plugins/spotify-squad",
+      "description": "AI-Native Squad — Spotify-model autonomous engineering team. 12 specialized agents (Tech Lead, Backend, Frontend, Mobile, UX, UI, Product, Scrum Master, DevOps, QA, Data, Security) with orchestrated collaboration and 17 domain-specific skills.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "squad",
+        "spotify-model",
+        "agents",
+        "orchestration",
+        "ai-native"
+      ]
+    },
+    {
+      "name": "agentic-value-loops",
+      "source": "./plugins/agentic-value-loops",
+      "description": "Continuous improvement engine that ships verified increments with constant quality. Loops for Feature Development, Maintenance & Security, Documentation Sync, and AI Tuning.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "loops",
+        "continuous-improvement",
+        "automations",
+        "ai-native"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,16 +6,63 @@ This project is based on and inspired by Peter Steinberger's pattern (`steipete/
 
 ---
 
+## 🧩 Install as a Claude Code Marketplace
+
+This repository ships a marketplace manifest (`.claude-plugin/marketplace.json`) so you can install its plugins directly inside Claude Code.
+
+### 1. Register the marketplace
+
+Inside a Claude Code session, run the slash command:
+
+```text
+/plugin marketplace add Andersonlimahw/ai-marketplace
+```
+
+You can also point at any Git URL or a local path:
+
+```text
+/plugin marketplace add https://github.com/Andersonlimahw/ai-marketplace.git
+/plugin marketplace add ./ai-marketplace          # local checkout
+```
+
+### 2. Browse & install plugins
+
+Open the interactive installer, or install a plugin by name using the `plugin@marketplace` syntax:
+
+```text
+/plugin                                            # browse the catalog UI
+/plugin install spotify-squad@ai-marketplace
+/plugin install agentic-value-loops@ai-marketplace
+```
+
+| Plugin | What you get |
+| --- | --- |
+| `spotify-squad` | 12 specialized agents (Tech Lead, Backend, Frontend, Mobile, UX, UI, Product, Scrum Master, DevOps, QA, Data, Security) + 17 domain skills. |
+| `agentic-value-loops` | Continuous-improvement loops: Feature Development, Maintenance & Security, Documentation Sync, AI Tuning. |
+
+### 3. Manage the marketplace
+
+```text
+/plugin marketplace list                           # show registered marketplaces
+/plugin marketplace update ai-marketplace          # pull the latest manifest
+/plugin marketplace remove ai-marketplace          # unregister
+```
+
+> Plugins bundle their own agents, skills, and commands — once installed they are auto-discovered by Claude Code. The standalone `skills/` in this repo are shared globally via symlinks instead (see **Installation & Symlink Setup** below).
+
+---
+
 ## 📂 Repository Structure
 
 - **`skills/`**: Reusable skills and prompt routers.
-  - [`senior-prompt-engineer`](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/senior-prompt-engineer/SKILL.md): Stage-0 prompt refiner and Execution Map (`EXEC-MAP v1`) builder.
-  - [`skills-selector`](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/skills-selector/SKILL.md): Meta-skill gatekeeper that dynamically decides which skills to load on-demand.
-  - [`smart-dispatch`](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/smart-dispatch/SKILL.md): Intelligent routing of implementations with fallback and YOLO-mode.
-  - [`karpathy-recipe`](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/karpathy-recipe/SKILL.md): Incremental development methodology (based on Karpathy's recipe).
-  - [`llm-wiki-curator`](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/llm-wiki-curator/SKILL.md): Automated maintenance of structured `llms.txt` documentation.
-  - [`token-saver`](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/token-saver/SKILL.md): Generic skill for installing and configuring token-saving tools.
-- **`plugins/`**: Installed plugins (such as `spotify-squad` and `agentic-value-loops`).
+  - [`senior-prompt-engineer`](./skills/senior-prompt-engineer/SKILL.md): Stage-0 prompt refiner and Execution Map (`EXEC-MAP v1`) builder.
+  - [`skills-selector`](./skills/skills-selector/SKILL.md): Meta-skill gatekeeper that dynamically decides which skills to load on-demand.
+  - [`smart-dispatch`](./skills/smart-dispatch/SKILL.md): Intelligent routing of implementations with fallback and YOLO-mode.
+  - [`karpathy-recipe`](./skills/karpathy-recipe/SKILL.md): Incremental development methodology (based on Karpathy's recipe).
+  - [`llm-wiki-curator`](./skills/llm-wiki-curator/SKILL.md): Automated maintenance of structured `llms.txt` documentation.
+  - [`token-saver`](./skills/token-saver/SKILL.md): Generic skill for installing and configuring token-saving tools.
+  - [`code-review-adversary`](./skills/code-review-adversary/SKILL.md): Senior-vs-junior adversarial PR review with configurable model, criticality, and inline-comment/resolve flow.
+- **`plugins/`**: Installable Claude Code plugins (`spotify-squad`, `agentic-value-loops`) — see [Install as a Claude Code Marketplace](#-install-as-a-claude-code-marketplace).
 - **`scripts/`**: Utility helpers.
   - `setup-symlinks.sh`: Script to automate the creation of global symbolic links.
   - `marketplace`: CLI interface for listing and managing IA tools in the repository.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,5 +32,5 @@ To initialize the repository and synchronize all your local AI CLIs:
    ```
 
 ## ⚖️ General Guidelines
-- For behavioral conventions, please read [AGENTS.md](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/AGENTS.md) at the root directory.
-- For session setup rules, check [CLAUDE.md](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/CLAUDE.md) at the root directory.
+- For behavioral conventions, please read [AGENTS.md](./AGENTS.md) at the root directory.
+- For session setup rules, check [CLAUDE.md](./CLAUDE.md) at the root directory.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -30,20 +30,20 @@ Execution
 ```
 
 ### 1. `senior-prompt-engineer`
-- **Location**: [skills/senior-prompt-engineer/SKILL.md](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/senior-prompt-engineer/SKILL.md)
+- **Location**: [skills/senior-prompt-engineer/SKILL.md](./skills/senior-prompt-engineer/SKILL.md)
 - **Role**: Prompts refiner & architect.
 - **Function**: Takes a raw, ambiguous task and hardens it into a definitive prompt using Anthropic's prompt engineering rules.
 - **Contract**: Generates an `EXEC-MAP v1` block mapping execution details (expected intent, effort, target executor, candidate models/skills).
 - **Triviality Gate**: Automatically skips refinement on simple queries (like "run tests") to save time and tokens.
 
 ### 2. `skills-selector`
-- **Location**: [skills/skills-selector/SKILL.md](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/skills-selector/SKILL.md)
+- **Location**: [skills/skills-selector/SKILL.md](./skills/skills-selector/SKILL.md)
 - **Role**: Dynamic gatekeeper.
 - **Function**: Rather than loading all available skills (which overwhelms the LLM context window), it intercepts requests and loads the minimal set of skills on-demand.
 - **Rule**: Limits loaded skills to a maximum of 2 per conversation turn to optimize input tokens.
 
 ### 3. `smart-dispatch`
-- **Location**: [skills/smart-dispatch/SKILL.md](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/smart-dispatch/SKILL.md)
+- **Location**: [skills/smart-dispatch/SKILL.md](./skills/smart-dispatch/SKILL.md)
 - **Role**: Intelligent router.
 - **Function**: Maps tasks to the appropriate model class based on complexity:
   - **Budget (e.g., Gemini Flash, Claude Haiku)**: Mechanical edits, documentation, linting, formatting.
@@ -56,7 +56,7 @@ Execution
 ## 🛠️ Specialty Skills
 
 ### 4. `karpathy-recipe`
-- **Location**: [skills/karpathy-recipe/SKILL.md](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/karpathy-recipe/SKILL.md)
+- **Location**: [skills/karpathy-recipe/SKILL.md](./skills/karpathy-recipe/SKILL.md)
 - **Concept**: Adapted from Andrej Karpathy's *"A Recipe for Training Neural Networks"*.
 - **Function**: Enforces a paranoid, step-by-step product building flow:
   1. Learn from real domain data.
@@ -65,11 +65,11 @@ Execution
   4. Add one feature "knob" at a time, running validation tests after each commit.
 
 ### 5. `llm-wiki-curator`
-- **Location**: [skills/llm-wiki-curator/SKILL.md](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/llm-wiki-curator/SKILL.md)
+- **Location**: [skills/llm-wiki-curator/SKILL.md](./skills/llm-wiki-curator/SKILL.md)
 - **Concept**: Keeps project documentation LLM-friendly.
 - **Function**: Automatically compiles the `docs/llms.txt` index block conforming to llmstxt.org guidelines. Audits for broken markdown links, orphan documents, and missing metadata front-matter.
 
 ### 6. `token-saver`
-- **Location**: [skills/token-saver/SKILL.md](file:///Users/andersonlimadev/Projects/IA/ai-marketplace/skills/token-saver/SKILL.md)
+- **Location**: [skills/token-saver/SKILL.md](./skills/token-saver/SKILL.md)
 - **Concept**: Facilitates setup of token saving tools.
 - **Function**: Launches an interactive CLI wizard to configure RTK, Caveman Mode, Graphify, and Context-Mode across projects.

--- a/plugins/spotify-squad/agents/security-engineer.md
+++ b/plugins/spotify-squad/agents/security-engineer.md
@@ -1,6 +1,32 @@
 ---
 name: security-engineer
-description: triggers for security audits, secure coding practices, vulnerability scanning, threat modeling, compliance checks, DevSecOps integration, penetration testing, secret management, and adversarial review
+description: >
+  Use this agent when the user needs help with security audits, secure coding practices,
+  vulnerability scanning, threat modeling, compliance checks (OWASP, GDPR, LGPD, SOC2),
+  DevSecOps integration, penetration testing, secret management, IAM, or adversarial review.
+  Also triggers for keywords: "security", "vulnerability", "threat model", "owasp", "sast",
+  "dast", "secret", "iam", "auth hardening", "pentest", "compliance", "devsecops".
+
+  <example>
+  Context: User wants a security review before shipping a feature
+  user: "Review our new file-upload endpoint for security issues before we deploy"
+  assistant: "I'll threat-model the upload flow (asset/trust boundaries), check for the OWASP risks (unrestricted file type/size, path traversal, SSRF on remote fetch, content sniffing), validate auth/authorization, and return prioritized findings with code-level remediations."
+  <commentary>Triggers on security audit requiring threat modeling and OWASP-based review</commentary>
+  </example>
+
+  <example>
+  Context: User needs to add automated security scanning to CI
+  user: "Integrate security scanning into our GitHub Actions pipeline"
+  assistant: "I'll add SAST (CodeQL/Semgrep), dependency scanning (SCA), and secret detection to the pipeline with severity gating, then document triage of the first results."
+  <commentary>Triggers on DevSecOps / CI security tooling integration</commentary>
+  </example>
+
+  <example>
+  Context: User suspects a vulnerability in auth logic
+  user: "Our JWT validation might be broken — can someone forge a token?"
+  assistant: "I'll audit the JWT validation: algorithm confusion (alg=none / RS256↔HS256), signature/issuer/audience/expiry checks, and key handling, then provide a hardened implementation and a regression test."
+  <commentary>Triggers on adversarial review of authentication/authorization logic</commentary>
+  </example>
 model: inherit
 color: red
 tools: ["Read", "Write", "Grep", "Bash"]

--- a/plugins/spotify-squad/agents/squad-orchestrator.md
+++ b/plugins/spotify-squad/agents/squad-orchestrator.md
@@ -36,6 +36,7 @@ description: >
   </example>
 model: inherit
 color: cyan
+tools: ["Read", "Write", "Grep", "Bash", "Task", "TodoWrite"]
 ---
 
 You are the **Tech Lead and Squad Orchestrator** — the central coordinator of an AI-native engineering squad built on the Spotify model. You lead a team of 11 specialized agents, decomposing complex requests into domain-specific tasks, routing work to the right specialists, and synthesizing their outputs into cohesive results.

--- a/skills/code-review-adversary/SKILL.md
+++ b/skills/code-review-adversary/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: code-review-adversary
+description: >
+  Adversarial code review where the reviewer plays a senior/expert software engineer who owns
+  and deeply knows this codebase, reviewing a Pull Request as if it was opened by a junior
+  developer. Ships sensible defaults but offers interactive configuration: which model the
+  reviewer uses, criticality/severity threshold, whether to post inline PR comments and then
+  resolve them, review scope (working diff, staged, branch-vs-main, or a GitHub PR number),
+  and optional auto-fix. Use when the user runs /code-review-adversary, says "review this PR
+  as a senior", "adversarial review", "review as if I'm a junior", "revisa como sênior",
+  "revisa essa PR com rigor", or wants a strict expert-grade review with mentoring feedback.
+---
+
+# Code Review Adversary — Senior-vs-Junior PR Review
+
+You are a **principal software engineer and long-time owner of this codebase**. The change under
+review was opened by a **junior developer**. Your job is to review it the way a demanding-but-fair
+senior reviewer would: catch real defects, protect the architecture, and *teach* — every blocking
+comment explains the "why" and shows the fix, because the author is still learning.
+
+You are skeptical by default. The PR is **not** assumed correct. Find what a junior most likely got
+wrong: edge cases, error handling, security, concurrency, performance, test gaps, and silent
+violations of the project's existing conventions.
+
+---
+
+## 0. Configuration (defaults + interactive)
+
+This skill runs with **defaults** so a bare `/code-review-adversary` works immediately. If the user
+passed explicit preferences in their message, honor them and skip the matching question. Otherwise,
+when the request is ambiguous, ask the user with **one** `AskUserQuestion` call (batch the questions
+below) before reviewing. If the user says "use defaults" / "just review", skip all questions.
+
+| Setting | Default | Options |
+| --- | --- | --- |
+| **Scope** | Current branch vs `main` | Working diff (uncommitted) · Staged only · Branch vs base · GitHub PR `#<n>` |
+| **Reviewer model** | `inherit` (current session model) | `opus` (deep, architectural) · `sonnet` (balanced, fast) · `haiku` (quick pass) |
+| **Criticality** | `Standard` | `Blocking-only` (ship-blockers) · `Standard` (blockers + majors) · `Strict` (everything, incl. nits & style) |
+| **Inline comments** | Off (summary report only) | On — post findings as inline PR comments via `gh` |
+| **Resolve flow** | N/A | If inline On: leave open · auto-resolve once addressed |
+| **Auto-fix** | Off | On — apply safe fixes to the working tree after review |
+
+### Interactive questions (only when not already specified)
+
+Ask at most these, as a single batched `AskUserQuestion`:
+
+1. **Scope** — "What should I review?" (working diff / staged / branch vs base / a PR number)
+2. **Reviewer model** — "How deep should the reviewer go?" (opus / sonnet / haiku) — map to depth, note the user can override with `/model`.
+3. **Criticality** — "How strict?" (blocking-only / standard / strict)
+4. **Inline comments** — "Post findings as inline PR comments, or just a summary report?" (+ if inline: resolve when addressed?)
+
+> When reviewing a **GitHub PR number**, inline comments require `gh` auth and write access. If
+> unavailable, fall back to the summary report and tell the user.
+
+---
+
+## 1. Gather the change
+
+Resolve scope to a concrete diff before reviewing:
+
+```bash
+# Branch vs base (default)
+git diff main...HEAD
+# Working diff
+git diff
+# Staged
+git diff --cached
+# GitHub PR
+gh pr diff <n>
+gh pr view <n> --json title,body,files,additions,deletions,author
+```
+
+Read the **full** changed files (not just hunks) for context, and read the neighbors the change
+touches (callers, tests, types) so you review against the real codebase, not in isolation.
+
+---
+
+## 2. Review methodology (junior-author lens)
+
+Review in priority order. For each finding, assume the junior took the first approach that "worked"
+and ask what they skipped.
+
+1. **Correctness** — off-by-one, null/undefined, wrong operator (`<` vs `<=`), incorrect async/await,
+   unhandled promise rejection, mutation of shared state, broken happy-path *and* sad-path.
+2. **Edge cases & inputs** — empty/huge inputs, unicode, timezones, negative numbers, concurrent
+   calls, pagination boundaries, partial failures.
+3. **Security** — injection (SQL/command/XSS), authz checks, secrets in code, unsafe deserialization,
+   SSRF, missing rate limits. (See `adversary-review` skill for the OWASP checklist.)
+4. **Error handling** — swallowed exceptions, generic `catch`, missing rollback, leaked resources.
+5. **Convention adherence** — does it match the existing patterns in **this** repo (naming, layering,
+   test style, lint rules)? A junior often invents a new pattern instead of reusing the established one.
+6. **Tests** — are the new paths actually covered? Do tests assert behavior or just run code? Are the
+   failing/sad paths tested, not only the happy path?
+7. **Performance** — N+1 queries, unnecessary loops, missing indexes, blocking I/O on hot paths.
+8. **Readability/maintainability** — only flag at `Strict` criticality; keep nits separate from blockers.
+
+**Adversarial bias:** before approving any block, try to *break* it — construct one concrete input or
+sequence that fails. If you can't articulate a failure, downgrade the finding's severity.
+
+---
+
+## 3. Severity model
+
+| Severity | Meaning | Gate |
+| --- | --- | --- |
+| 🔴 **Blocker** | Bug, security hole, data loss, or breaks existing behavior | Must fix before merge |
+| 🟠 **Major** | Real risk, missing test for critical path, convention violation with impact | Should fix |
+| 🟡 **Minor** | Quality/readability/perf nit, no functional risk | Optional |
+| 🟢 **Praise** | Something done well — call it out (mentoring) | — |
+
+Apply the **Criticality** setting: blocking-only reports 🔴 only; standard reports 🔴+🟠; strict
+reports everything including 🟡 and 🟢.
+
+---
+
+## 4. Output
+
+### Summary report (always)
+
+```markdown
+## 🧑‍🏫 Senior Review — <scope>
+
+**Verdict:** ❌ Request changes | ⚠️ Approve with comments | ✅ Approve
+**Model:** <reviewer model> · **Criticality:** <level> · **Files:** <n> (+<add> / -<del>)
+
+### 🔴 Blockers (N)
+- `path/file.ts:42` — <problem>. **Why it matters:** <impact>. **Fix:** <concrete change>.
+
+### 🟠 Majors (N)
+- ...
+
+### 🟡 Minors (N)         # strict only
+### 🟢 Good work
+- <genuine praise>
+
+### 📚 Mentoring note
+<1–3 sentences teaching the underlying principle, since the author is junior>
+```
+
+### Inline PR comments (when enabled)
+
+Post each 🔴/🟠 finding as an inline comment on the exact line, then summarize:
+
+```bash
+gh pr comment <n> --body "<summary>"
+# Inline review comments via the reviews API:
+gh api repos/{owner}/{repo}/pulls/<n>/comments -f body="..." -f commit_id="<sha>" -f path="..." -F line=<line> -f side="RIGHT"
+```
+
+**Resolve flow** (if enabled): after the author/you address a comment, resolve the corresponding
+review thread (`gh api graphql` `resolveReviewThread`) and note it as resolved in the summary. If
+resolve is off, leave threads open for the author to handle.
+
+### Auto-fix (when enabled)
+
+Apply only **safe, unambiguous** fixes (the 🔴 with a clear single correct change) to the working
+tree, leave judgment calls for the author, and list exactly what was changed. Never push or commit
+unless the user explicitly asks.
+
+---
+
+## 5. Guardrails
+
+- Review the diff, not the developer — feedback is about the code, framed to teach.
+- Don't invent problems to look thorough; an honest ✅ is a valid outcome.
+- Don't restyle code that already follows repo conventions just to match personal taste.
+- Quote errors/log lines exactly. Reference findings as `file_path:line`.
+- For deep security/architecture passes, compose with the `adversary-review` skill instead of
+  duplicating its OWASP and architecture checklists here.


### PR DESCRIPTION
## Summary
AI-native review of the assets created in PR #1 (`spotify-squad`, `agentic-value-loops`, skills, docs), shipping the fixes plus the missing piece that makes this repo actually usable as a **plugin marketplace** for Claude Code (and shareable cross-CLI for Codex/OpenCode/Agy).

## Review findings → adjustments
- **Missing marketplace manifest (critical):** the repo is named `ai-marketplace` but had no `.claude-plugin/marketplace.json`, so it could not be registered/installed by Claude Code. **Added** it, listing both plugins.
- **`security-engineer` agent below the squad bar:** had a weak one-line `description` with no `Use this agent when` framing and no `<example>` blocks (every other squad agent has them). **Rewritten** to the standard format with trigger keywords + 3 examples.
- **`squad-orchestrator` couldn't delegate:** no `tools` field. **Added** `Task` and `TodoWrite` (plus Read/Write/Grep/Bash) so the orchestrator can actually route work to specialists.
- **Hardcoded absolute paths:** README/docs linked to `file:///Users/andersonlimadev/...`, broken for anyone else. **Replaced** with relative `./` links.

## New feature
- **`/code-review-adversary` skill:** adversarial PR review where the reviewer is a senior/expert owner of the codebase and the author is treated as a junior dev. Ships sensible **defaults** plus **interactive** configuration (reviewer model, criticality level, post inline comments + resolve flow, scope: working diff / staged / branch / GitHub PR#, optional auto-fix). Mentoring-oriented output (explains the "why", includes praise).

## Marketplace availability (initial goal)
README now documents the full flow:
```text
/plugin marketplace add Andersonlimahw/ai-marketplace
/plugin install spotify-squad@ai-marketplace
/plugin install agentic-value-loops@ai-marketplace
```
Plugins are Claude Code-native; the standalone `skills/` remain shared across Codex/OpenCode/Agy via the existing symlink setup (documented in README).

## Testing
- [x] All JSON manifests validated (`marketplace.json`, both `plugin.json`).
- [x] All `SKILL.md` files have required `name` + `description` frontmatter.
- [x] No remaining absolute `file://` path leaks in `*.md` / `*.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)