### PR TITLE
feat(marketplace): catalog new CI/CD plugins and core skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-marketplace",
+  "name": "lemon-ai-hub",
   "owner": {
     "name": "Anderson Lima",
     "url": "https://andersonlimahw.github.io"

--- a/.claude/plugins/a11y-guardian/.claude-plugin/plugin.json
+++ b/.claude/plugins/a11y-guardian/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "a11y-guardian",
+  "version": "1.0.0",
+  "description": "Accessibility guardian plugin. Continuous WCAG 2.1 AA/AAA compliance monitoring for web projects. Integrates static analysis of React/Vue/HTML components, contrast ratio checks, ARIA validation, keyboard navigation audit, and generates actionable HTML reports. Pairs with a11y-audit skill.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["accessibility", "wcag", "a11y", "aria", "contrast", "screen-reader", "keyboard", "compliance"]
+}

--- a/.claude/plugins/a11y-guardian/skills/a11y-guardian.md
+++ b/.claude/plugins/a11y-guardian/skills/a11y-guardian.md
@@ -1,0 +1,50 @@
+---
+name: a11y-guardian
+description: Continuous accessibility monitoring. Runs WCAG 2.1 audit on every PR, blocks merge on CRITICAL violations, and posts inline PR comments with fixes. Use when setting up CI accessibility gates or reviewing PR for a11y regressions.
+---
+
+# A11y Guardian
+
+CI/CD accessibility gate. Block regressions. Fix inline.
+
+## Commands
+
+```
+/a11y-guardian setup       — configure CI hook (GitHub Actions / pre-commit)
+/a11y-guardian pr          — audit current git diff for a11y regressions
+/a11y-guardian baseline    — snapshot current a11y score as baseline
+/a11y-guardian compare     — compare current score vs baseline
+```
+
+## CI Configuration
+
+```yaml
+# .github/workflows/a11y.yml
+name: Accessibility Audit
+on: [pull_request]
+jobs:
+  a11y:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npx axe-cli http://localhost:3000 --exit
+```
+
+## Pre-commit Hook
+
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+changed_tsx=$(git diff --cached --name-only | grep '\.tsx\?$')
+if [ -n "$changed_tsx" ]; then
+  echo "Running a11y check on changed components..."
+  npx eslint $changed_tsx --plugin jsx-a11y --rule 'jsx-a11y/alt-text: error'
+fi
+```
+
+## Integration with a11y-audit skill
+
+This plugin provides CI/CD infrastructure.
+Use `/a11y-audit` for deep interactive audits.
+Use `/a11y-guardian setup` to enforce audit in CI.

--- a/.claude/plugins/async-advisor/.claude-plugin/plugin.json
+++ b/.claude/plugins/async-advisor/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "async-advisor",
+  "version": "1.0.0",
+  "description": "Async and concurrency static analysis plugin. Scans TypeScript/JavaScript codebases for race conditions, unbounded Promise.all, missing AbortController, swallowed rejections, and N+1 async patterns. Runs as a pre-commit hook or CI check and provides inline fix suggestions.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["async", "concurrency", "race-condition", "promises", "async-await", "p-limit", "abort-controller", "memory-leak", "node-js", "typescript"]
+}

--- a/.claude/plugins/async-advisor/skills/async-advisor.md
+++ b/.claude/plugins/async-advisor/skills/async-advisor.md
@@ -1,0 +1,60 @@
+---
+name: async-advisor
+description: Async pattern CI gate and PR review. Detects promise pitfalls, race conditions, and unbounded parallelism in changed files. Posts inline PR comments with corrected code. Use when setting up async quality gates or reviewing a PR with complex async logic.
+---
+
+# Async Advisor Plugin
+
+Catch async bugs in CI before they hit production.
+
+## Commands
+
+```
+/async-advisor setup       — install ESLint async rules + pre-commit hook
+/async-advisor pr          — check async patterns in current git diff
+/async-advisor scan        — full codebase async audit
+/async-advisor rules       — show all enforced rules with rationale
+```
+
+## ESLint Rules Configured
+
+```json
+{
+  "no-floating-promises": "error",
+  "no-misused-promises": "error",
+  "await-thenable": "error",
+  "require-await": "warn",
+  "@typescript-eslint/no-explicit-any": "warn",
+  "promise/always-return": "error",
+  "promise/catch-or-return": "error"
+}
+```
+
+## PR Inline Comments
+
+On a PR touching `src/api/reports.ts`:
+
+```
+⚠️ Line 45: Unbounded Promise.all over large array
+   Promise.all(reportIds.map(...)) — reportIds can be up to 5,000 items
+   → Wrap with pLimit(20) to avoid connection pool exhaustion
+   
+   import pLimit from 'p-limit'
+   const limit = pLimit(20)
+   const results = await Promise.all(reportIds.map(id => limit(() => ...)))
+```
+
+```
+❌ Line 89: Floating promise (swallowed rejection)
+   sendEmail(user) — no await, no .catch()
+   → Add: await sendEmail(user) OR sendEmail(user).catch(logger.error)
+```
+
+## CI Configuration
+
+```yaml
+- name: Async pattern check
+  run: npx eslint src/ --rule 'no-floating-promises: error' --ext .ts,.tsx
+```
+
+Pairs with `/async-patterns` skill for deep interactive analysis.

--- a/.claude/plugins/bundle-watch/.claude-plugin/plugin.json
+++ b/.claude/plugins/bundle-watch/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "bundle-watch",
+  "version": "1.0.0",
+  "description": "Bundle size monitoring and budget enforcement plugin. Tracks JS/CSS bundle size per commit, blocks PRs that exceed size budgets, posts bundle size diff comments on PRs, and generates size trend charts. Supports Vite, Webpack, Next.js, Remix, and Rollup build outputs.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["bundle-size", "performance", "webpack", "vite", "nextjs", "tree-shaking", "code-splitting", "web-vitals"]
+}

--- a/.claude/plugins/bundle-watch/skills/bundle-watch.md
+++ b/.claude/plugins/bundle-watch/skills/bundle-watch.md
@@ -1,0 +1,67 @@
+---
+name: bundle-watch
+description: Bundle size CI gate and trend tracking. Compares bundle size of current branch vs main, posts PR comment with size diff, and blocks merge if budget is exceeded. Use when setting up bundle size enforcement or investigating a sudden size increase in CI.
+---
+
+# Bundle Watch Plugin
+
+PR-level bundle size gating. No surprises in production.
+
+## Commands
+
+```
+/bundle-watch setup              — configure CI gate + size budgets
+/bundle-watch diff               — compare current branch bundle vs main
+/bundle-watch budget <kb>        — set or update size budget
+/bundle-watch history            — show bundle size trend over last 30 commits
+/bundle-watch blame <chunk>      — find what commit caused a chunk to grow
+```
+
+## CI Setup (GitHub Actions)
+
+```yaml
+name: Bundle Size Check
+on: [pull_request]
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci && npm run build
+      - uses: andersonlimahw/bundle-watch-action@v1
+        with:
+          budget_kb: 200
+          fail_on_exceed: true
+```
+
+## PR Comment Example
+
+```
+📦 Bundle Size Report
+
+          main    PR      diff
+─────────────────────────────
+Total    284 KB  312 KB  +28 KB ❌ (budget: 300 KB)
+/app     180 KB  195 KB  +15 KB
+/checkout 48 KB   62 KB  +14 KB ⚠️
+
+Top additions:
+  + react-pdf  (+38 KB) — loaded eagerly, consider dynamic import
+  - lodash-es  (-10 KB) — ✅ good removal
+```
+
+## Budget Configuration
+
+```json
+// bundle-watch.config.json
+{
+  "budgets": {
+    "total": { "maxKB": 300, "warnKB": 250 },
+    "/app": { "maxKB": 200 },
+    "/checkout": { "maxKB": 60 }
+  },
+  "baseline": "main"
+}
+```
+
+Pairs with `/bundle-analyzer` skill for deep analysis of violations.

--- a/.claude/plugins/chaos-runner/.claude-plugin/plugin.json
+++ b/.claude/plugins/chaos-runner/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "chaos-runner",
+  "version": "1.0.0",
+  "description": "Chaos engineering orchestration plugin. Manages chaos experiments via Toxiproxy, chaos-monkey scripts, and kubectl. Schedules regular chaos game days, tracks experiment results over time, and verifies steady-state hypotheses automatically. Integrates with Grafana for before/after metric comparison.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["chaos-engineering", "resilience", "fault-injection", "toxiproxy", "circuit-breaker", "gameday", "sre", "reliability"]
+}

--- a/.claude/plugins/chaos-runner/skills/chaos-runner.md
+++ b/.claude/plugins/chaos-runner/skills/chaos-runner.md
@@ -1,0 +1,70 @@
+---
+name: chaos-runner
+description: Chaos experiment orchestration and scheduling. Runs predefined chaos scenarios (latency injection, pod kill, dependency outage), records results, and tracks resilience score over time. Use when scheduling a game day, setting up weekly chaos tests, or verifying that a new circuit breaker works under fault conditions.
+---
+
+# Chaos Runner Plugin
+
+Scheduled fault injection. Automated resilience scoring.
+
+## Commands
+
+```
+/chaos-runner run <experiment>   — execute a named experiment
+/chaos-runner schedule weekly    — schedule weekly chaos (random pod kill)
+/chaos-runner history            — show past experiment results
+/chaos-runner score              — current resilience score (0-100)
+/chaos-runner game-day           — orchestrate a full game day session
+```
+
+## Experiment Library
+
+Pre-built experiments (run by name):
+
+| Name | What It Does |
+|------|-------------|
+| `pod-kill` | Kills a random pod from target deployment |
+| `db-latency-500ms` | Adds 500ms to all DB connections via toxiproxy |
+| `api-timeout` | Makes payment API time out after 3s |
+| `disk-pressure` | Fills disk to 90% on one node |
+| `memory-hog` | Allocates 80% of available heap |
+| `network-partition` | Blocks all traffic between service A and B |
+
+## Game Day Orchestration
+
+```
+/chaos-runner game-day
+
+Phase 1 — Baseline (10 min)
+  → Measure: p95 latency, error rate, uptime
+  → Confirm steady state
+
+Phase 2 — Experiment (30 min)
+  → Run: db-latency-500ms
+  → Monitor: circuit breakers, fallbacks, error messages
+
+Phase 3 — Recovery (10 min)
+  → Remove fault
+  → Confirm return to steady state
+
+Phase 4 — Report
+  → Resilience score: 78/100
+  → Failed: circuit breaker opened too slowly (12s, target <5s)
+  → Action item: reduce CB threshold from 10 failures to 5
+```
+
+## Resilience Score
+
+```
+RESILIENCE SCORE — 2026-06-14
+================================
+Total: 78/100
+
+Detection speed:   85/100  (alert in 2min, target <3min) ✅
+Recovery speed:    70/100  (recovered in 4min, target <2min) ⚠️
+Blast radius:      90/100  (only /checkout affected, not /browse) ✅
+User experience:   65/100  (users saw 500 instead of fallback message) ❌
+Circuit breaker:   80/100  (opened correctly, but closed too fast) ⚠️
+```
+
+Pairs with `/chaos-test` skill for experiment design.

--- a/.claude/plugins/code-smell-detector/.claude-plugin/plugin.json
+++ b/.claude/plugins/code-smell-detector/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "code-smell-detector",
+  "version": "1.0.0",
+  "description": "Automated code smell tracking and trend plugin. Runs smell detection on every PR, tracks smell density per file over time, identifies files with worsening trends, and generates weekly code quality reports. Detects god classes, long methods, feature envy, duplicate code, and dead code without requiring linter configuration.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["code-quality", "code-smell", "refactoring", "technical-debt", "god-class", "duplicate-code", "dead-code", "complexity", "maintainability"]
+}

--- a/.claude/plugins/code-smell-detector/skills/code-smell-detector.md
+++ b/.claude/plugins/code-smell-detector/skills/code-smell-detector.md
@@ -1,0 +1,65 @@
+---
+name: code-smell-detector
+description: PR-level code smell gating and trend tracking. Detects new smells introduced in a PR, blocks merge if smell density exceeds threshold, tracks file-level smell trends over time, and generates weekly maintainability reports. Use when enforcing code quality standards in CI or monitoring technical debt accumulation.
+---
+
+# Code Smell Detector Plugin
+
+Quality gates on every PR. Trend tracking over time.
+
+## Commands
+
+```
+/code-smell-detector setup       — configure CI quality gate
+/code-smell-detector pr          — analyze smells introduced in current PR
+/code-smell-detector trend       — show smell density trend (last 30 days)
+/code-smell-detector hotspots    — files with worst smell density
+/code-smell-detector report      — weekly maintainability report
+```
+
+## PR Gate
+
+Blocks merge if PR introduces:
+- New god class (>300 lines, >10 methods)
+- Method longer than 50 lines
+- Duplication of >15 lines found elsewhere in codebase
+- >3 new magic numbers
+
+```
+CODE SMELL PR CHECK — PR #247
+================================
+⚠️ 2 new smells introduced (non-blocking, warning)
+❌ 1 critical smell introduced (BLOCKING)
+
+  [BLOCK] src/services/PaymentService.ts — GOD CLASS
+          File grew from 180 → 520 lines in this PR
+          Added 8 new methods across 4 different concerns
+          → Break into: PaymentGatewayService, RefundService, InvoiceService
+
+  [WARN] src/utils/checkout.ts:45 — method too long (78 lines)
+  [WARN] src/utils/checkout.ts:12 — magic number 86400 (seconds/day?)
+         → const SECONDS_PER_DAY = 86_400
+```
+
+## Trend Report
+
+```
+SMELL TREND — last 30 days
+============================
+Smell density: 2.4 → 2.1 smells/100 lines ✅ (improving)
+
+HOTSPOT FILES (by smell density)
+  src/services/UserService.ts    4.8/100  ↑ worsening
+  src/api/checkout.ts            3.2/100  → stable
+  src/components/AdminPanel.tsx  2.9/100  ↓ improving
+```
+
+## Weekly Report
+
+Generated every Monday:
+- Overall smell density vs last week
+- Top 5 files added/removed from hotspot list
+- Recommended refactors ranked by impact
+- Team velocity correlation (high smell density = slower feature delivery)
+
+Pairs with `/code-smell` skill for deep interactive analysis.

--- a/.claude/plugins/commit-quality/.claude-plugin/plugin.json
+++ b/.claude/plugins/commit-quality/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "commit-quality",
+  "version": "1.0.0",
+  "description": "Commit message quality enforcement plugin. Validates Conventional Commits format, enforces max diff size per commit, detects commits that mix unrelated changes, suggests atomic commit splits, and generates CHANGELOG entries from commit history. Integrates with commitlint, husky, and CI pipelines.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["conventional-commits", "commitlint", "git", "changelog", "commit-message", "atomic-commits", "husky", "git-hooks", "semver"]
+}

--- a/.claude/plugins/commit-quality/skills/commit-quality.md
+++ b/.claude/plugins/commit-quality/skills/commit-quality.md
@@ -1,0 +1,84 @@
+---
+name: commit-quality
+description: Commit message linting, atomic commit enforcement, and changelog generation. Validates Conventional Commits format, warns on oversized diffs, detects mixed-concern commits, and generates changelog from history. Use when setting up commit standards, reviewing commit hygiene, or generating a release changelog.
+---
+
+# Commit Quality Plugin
+
+Atomic commits. Consistent messages. Auto-changelog.
+
+## Commands
+
+```
+/commit-quality setup          — install commitlint + husky hooks
+/commit-quality lint           — check recent commits against Conventional Commits
+/commit-quality analyze        — detect mixed-concern commits in current branch
+/commit-quality split          — suggest how to split a large commit
+/commit-quality changelog      — generate CHANGELOG from commits since last tag
+```
+
+## Conventional Commits Enforcement
+
+Valid formats:
+```
+feat(checkout): add coupon code support
+fix(auth): prevent session expiry on tab switch
+chore(deps): upgrade React to 18.3.0
+docs(api): update authentication section
+perf(db): add composite index on orders table
+refactor(user): extract UserService from controller
+test(checkout): add coupon validation edge cases
+```
+
+## Lint Results
+
+```
+COMMIT QUALITY — last 5 commits
+==================================
+✅ feat(checkout): add coupon code support
+✅ fix(auth): prevent session expiry
+⚠️ "updated stuff and fixed things" — no type, no scope, no description
+❌ "WIP" — work-in-progress commit on main branch (squash before merge)
+⚠️ feat(checkout): add payment + fix bug + refactor service ← mixed concerns
+    → Split into: feat(checkout), fix(payment), refactor(checkout)
+```
+
+## Mixed Concern Detection
+
+```
+/commit-quality analyze
+
+Commit abc1234 touches:
+  src/auth/service.ts       — auth concern
+  src/payment/gateway.ts    — payment concern
+  src/ui/Button.tsx         — UI concern
+  tests/payment.test.ts     — test concern
+
+→ 4 concerns in 1 commit
+→ Suggested split:
+  1. refactor(auth): extract token refresh logic
+  2. fix(payment): handle gateway timeout
+  3. style(ui): update Button hover state
+  4. test(payment): add timeout edge case
+```
+
+## Changelog Generation
+
+```
+/commit-quality changelog v3.3.0..HEAD
+
+## [3.4.0] — 2026-06-14
+
+### Features
+- **checkout**: add coupon code support (#142)
+- **products**: add featured products filter (#138)
+
+### Bug Fixes
+- **auth**: prevent session expiry on tab switch (#145)
+- **payment**: handle gateway timeout gracefully (#143)
+
+### Performance
+- **db**: add composite index on orders table (#140)
+```
+
+Pairs with `/git-save` and `/git-commit` skills for commit workflows.

--- a/.claude/plugins/db-advisor/.claude-plugin/plugin.json
+++ b/.claude/plugins/db-advisor/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "db-advisor",
+  "version": "1.0.0",
+  "description": "Database optimization advisor plugin. Continuously monitors query performance, detects N+1 queries from ORM logs, suggests missing indexes, identifies table bloat, tracks connection pool health, and generates weekly database health reports. Supports PostgreSQL, MySQL, SQLite, and PlanetScale.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["database", "postgresql", "mysql", "sqlite", "query-optimization", "indexes", "n+1-queries", "connection-pool", "query-performance", "prisma", "drizzle"]
+}

--- a/.claude/plugins/db-advisor/skills/db-advisor.md
+++ b/.claude/plugins/db-advisor/skills/db-advisor.md
@@ -1,0 +1,59 @@
+---
+name: db-advisor
+description: Automated database query monitoring and N+1 detection. Analyzes ORM query logs, detects repeated queries (N+1 pattern), suggests eager loading or batching fixes, and tracks query count per request. Use when adding DB monitoring, investigating slow endpoints, or reviewing ORM query patterns in a PR.
+---
+
+# DB Advisor Plugin
+
+Continuous query monitoring. N+1 caught before production.
+
+## Commands
+
+```
+/db-advisor monitor              — enable query logging for current session
+/db-advisor n+1                  — detect N+1 patterns in ORM logs
+/db-advisor slow-queries         — list queries slower than 100ms
+/db-advisor explain <query>      — run EXPLAIN ANALYZE on a query
+/db-advisor health               — overall DB health report
+/db-advisor weekly-report        — generate markdown health report
+```
+
+## N+1 Detection
+
+Automatically detects patterns like:
+```
+SELECT * FROM users WHERE id = 1    ─┐
+SELECT * FROM users WHERE id = 2     │ N+1 detected
+SELECT * FROM users WHERE id = 3     │ 50 identical queries
+...                                  ─┘
+```
+
+Suggests fix:
+```typescript
+// ❌ N+1 — 1 query per order
+const orders = await prisma.order.findMany()
+for (const order of orders) {
+  const user = await prisma.user.findUnique({ where: { id: order.userId } })
+}
+
+// ✅ eager load — 1 query total
+const orders = await prisma.order.findMany({
+  include: { user: true }
+})
+```
+
+## Health Report
+
+```
+DB HEALTH — 2026-06-14
+========================
+Connections: 28/50 (56%) ✅
+Slow queries (>100ms): 14 this hour ⚠️
+  Slowest: SELECT * FROM events (avg 820ms) — add index on event_type
+N+1 patterns: 3 detected in last hour
+  /api/products endpoint: 48 user queries per request → use include
+Table bloat: orders_archive 4.2 GB (87% dead rows) — run VACUUM ANALYZE
+Replication lag: 0ms ✅
+```
+
+Pairs with `/db-index-advisor` skill for index optimization.

--- a/.claude/plugins/feature-flags/.claude-plugin/plugin.json
+++ b/.claude/plugins/feature-flags/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "feature-flags",
+  "version": "1.0.0",
+  "description": "Feature flag lifecycle management plugin. Tracks all flags across the codebase, detects stale flags (>90 days enabled at 100%), enforces naming conventions, auto-generates flag registry, and produces cleanup PRs for dead flags. Integrates with LaunchDarkly, GrowthBook, Unleash, Statsig, and env-var flag patterns.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["feature-flags", "toggles", "launchdarkly", "growthbook", "unleash", "rollout", "ab-testing", "experiments"]
+}

--- a/.claude/plugins/feature-flags/skills/feature-flags.md
+++ b/.claude/plugins/feature-flags/skills/feature-flags.md
@@ -1,0 +1,46 @@
+---
+name: feature-flags
+description: Feature flag registry management. Scans codebase for all flags, tracks age and rollout state, generates cleanup reports, and creates removal PRs for stale flags. Use when managing technical debt from old flags or auditing flag hygiene across the repo.
+---
+
+# Feature Flags Plugin
+
+Registry + hygiene for all your feature toggles.
+
+## Commands
+
+```
+/feature-flags registry       — list all flags found in codebase
+/feature-flags stale          — flags that are 100% enabled >90 days (cleanup candidates)
+/feature-flags cleanup <name> — generate PR removing a flag (keep enabled code path)
+/feature-flags report         — markdown report of all flags with owner and age
+```
+
+## Flag Registry (auto-generated)
+
+Scans for patterns: `FLAGS.X`, `isOn('...')`, `process.env.FLAG_*`, `variation('...')`
+
+```
+FLAG REGISTRY — 2026-06-14
+============================
+feat_new_checkout      100%   Active   Added: 2026-01-10  Owner: @checkout-team  ← STALE
+exp_pricing_v2          50%   Active   Added: 2026-05-20  Owner: @growth
+ops_disable_ai_recs      0%   Disabled Added: 2026-03-01  Owner: @ml-team
+tmp_v3_migration       100%   Active   Added: 2026-02-15  Owner: @backend  ← STALE
+```
+
+## Stale Flag Report
+
+Flag is "stale" when:
+- Rollout is 100% AND age > 90 days, OR
+- Rollout is 0% AND age > 30 days (was never turned on)
+
+## Cleanup PR Generation
+
+`/feature-flags cleanup feat_new_checkout` will:
+1. Remove all `if (FLAGS.feat_new_checkout)` conditionals
+2. Keep the enabled code path
+3. Delete tests that test the disabled path
+4. Open a PR with the changes
+
+Pairs with `/feature-flag` skill for implementation guidance.

--- a/.claude/plugins/i18n-sync/.claude-plugin/plugin.json
+++ b/.claude/plugins/i18n-sync/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "i18n-sync",
+  "version": "1.0.0",
+  "description": "Internationalization key synchronization plugin. Keeps locale JSON files in sync across all supported languages, detects missing and orphaned keys, enforces key naming conventions, blocks PRs that introduce hardcoded strings, and generates translation stubs for new keys. Supports i18next, react-intl, vue-i18n, next-intl, and custom JSON locale files.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["i18n", "l10n", "internationalization", "localization", "translations", "i18next", "react-intl", "vue-i18n", "locale"]
+}

--- a/.claude/plugins/i18n-sync/skills/i18n-sync.md
+++ b/.claude/plugins/i18n-sync/skills/i18n-sync.md
@@ -1,0 +1,57 @@
+---
+name: i18n-sync
+description: Locale file synchronization and CI enforcement. Detects missing keys added to base locale, auto-stubs them in all other locales, blocks PRs with hardcoded strings, and generates a translation completeness badge. Use when onboarding a new locale or enforcing translation discipline in CI.
+---
+
+# i18n Sync Plugin
+
+Keep all locales in sync. Zero missing keys in CI.
+
+## Commands
+
+```
+/i18n-sync check           — compare all locales vs base locale
+/i18n-sync stub            — add missing keys to all locales with [UNTRANSLATED] prefix
+/i18n-sync clean           — remove orphaned keys from all locales
+/i18n-sync ci-setup        — configure pre-commit + GitHub Actions check
+/i18n-sync badge           — generate translation completeness badge
+```
+
+## CI Gate
+
+Blocks merge if:
+- New keys added to `en.json` without stubs in other locales
+- Hardcoded string detected in `.tsx`/`.vue` files added in PR
+- Any locale file is invalid JSON
+
+```yaml
+# .github/workflows/i18n.yml
+- name: Check i18n completeness
+  run: npx i18n-sync check --fail-on-missing
+```
+
+## Auto-Stub Example
+
+New key added to `en.json`:
+```json
+{ "checkout.coupon.invalid": "Coupon code is not valid" }
+```
+
+Auto-stubbed in `pt-BR.json`:
+```json
+{ "checkout.coupon.invalid": "[UNTRANSLATED] Coupon code is not valid" }
+```
+
+Auto-stubbed in `es.json`:
+```json
+{ "checkout.coupon.invalid": "[UNTRANSLATED] Coupon code is not valid" }
+```
+
+## Pre-commit Hook
+
+```bash
+# Runs on every commit touching locale files
+npx i18n-sync check --base en --locales pt-BR,es,fr,de
+```
+
+Pairs with `/i18n-audit` skill for comprehensive manual audits.

--- a/.claude/plugins/incident-center/.claude-plugin/plugin.json
+++ b/.claude/plugins/incident-center/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "incident-center",
+  "version": "1.0.0",
+  "description": "Incident management hub plugin. Manages active incidents, runbooks, on-call rotations, and postmortem backlog. Integrates with PagerDuty, OpsGenie, and Slack. Auto-generates incident channels, tracks MTTR/MTTD metrics over time, and maintains a searchable postmortem library for recurring issue detection.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["incident-management", "on-call", "runbook", "postmortem", "sre", "mttr", "pagerduty", "opsgenie", "reliability", "alerting"]
+}

--- a/.claude/plugins/incident-center/skills/incident-center.md
+++ b/.claude/plugins/incident-center/skills/incident-center.md
@@ -1,0 +1,53 @@
+---
+name: incident-center
+description: Incident tracking, MTTR/MTTD metrics, and postmortem library. Manages the full incident lifecycle from declaration to postmortem close. Use when declaring a new incident, reviewing MTTR trends, searching for similar past incidents, or tracking open action items from postmortems.
+---
+
+# Incident Center Plugin
+
+Full incident lifecycle. From alert to action items closed.
+
+## Commands
+
+```
+/incident-center declare P1 "Checkout errors"   — open new incident
+/incident-center status                          — list open incidents
+/incident-center close INC-042                  — mark resolved
+/incident-center postmortem INC-042             — generate postmortem template
+/incident-center search "database timeout"      — find similar past incidents
+/incident-center metrics                        — MTTR/MTTD/frequency report
+/incident-center action-items                  — list all open follow-up tasks
+```
+
+## Incident Registry
+
+```
+OPEN INCIDENTS — 2026-06-14
+=============================
+INC-047  P1  Checkout 500 errors  44m open  IC: @dev  #inc-2026-06-14-checkout
+INC-046  P2  Search latency >2s   2h open   IC: @ops  #inc-2026-06-14-search
+```
+
+## MTTR/MTTD Metrics
+
+```
+INCIDENT METRICS — Last 90 days
+=================================
+Total incidents: 23  (P0: 1, P1: 8, P2: 14)
+MTTD (mean time to detect):  4.2 min  (target: <5 min) ✅
+MTTR (mean time to resolve): 47 min   (target: <60 min) ✅
+Recurrence rate: 22% (5 incidents were repeats)
+
+TOP RECURRING ISSUES
+  1. DB connection pool exhaustion — 3 incidents (add better pool monitoring)
+  2. Payment API timeout — 2 incidents (circuit breaker threshold too high)
+```
+
+## Postmortem Search
+
+`/incident-center search "memory leak"` searches past postmortems to find:
+- Same root cause occurred before
+- What was the fix last time
+- Whether that action item was actually completed
+
+Pairs with `/incident-runbook` skill for runbook generation.

--- a/.claude/plugins/load-test-runner/.claude-plugin/plugin.json
+++ b/.claude/plugins/load-test-runner/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "load-test-runner",
+  "version": "1.0.0",
+  "description": "Load testing orchestration plugin. Manages k6 and Artillery test suites, schedules nightly soak tests, stores historical performance baselines, detects performance regressions between releases, and generates Grafana-compatible performance reports. Tracks p50/p95/p99 trends over time.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["load-testing", "k6", "artillery", "performance", "slo", "p99", "latency", "throughput", "stress-test", "benchmark"]
+}

--- a/.claude/plugins/load-test-runner/skills/load-test-runner.md
+++ b/.claude/plugins/load-test-runner/skills/load-test-runner.md
@@ -1,0 +1,59 @@
+---
+name: load-test-runner
+description: Load test suite management and regression detection. Maintains a library of k6/Artillery scripts, runs them on schedule or pre-release, compares results to baseline, and alerts on p99 regressions. Use when setting up pre-release performance gates or tracking latency trends across versions.
+---
+
+# Load Test Runner Plugin
+
+Performance baselines, regression detection, nightly tests.
+
+## Commands
+
+```
+/load-test-runner init          — scaffold load test suite for this project
+/load-test-runner run smoke     — quick smoke test (1 VU, 1 min)
+/load-test-runner run peak      — peak load test vs SLO
+/load-test-runner run soak      — 2h soak test (detect memory leaks)
+/load-test-runner baseline      — save current results as new baseline
+/load-test-runner compare       — compare last run vs baseline
+/load-test-runner schedule      — set up nightly test cron
+```
+
+## Test Suite Structure
+
+```
+load-tests/
+  smoke.js          — 1 VU, 1 min, verify script works
+  peak.js           — 50 VUs, 30 min, simulates peak traffic
+  soak.js           — 10 VUs, 2 hours, memory leak detection
+  spike.js          — ramp 0→500 in 30s, check recovery
+  baselines/
+    v3.2.0.json     — performance baseline per release
+    v3.3.0.json
+```
+
+## Regression Detection
+
+```
+REGRESSION ALERT — v3.4.0 vs v3.3.0
+=======================================
+❌ p99 latency regression detected
+
+Endpoint       v3.3.0   v3.4.0   Change
+/api/products    280ms    890ms   +218%  ← REGRESSION
+/api/checkout    450ms    460ms    +2%   ✅
+/api/users       120ms    115ms    -4%   ✅ (improved)
+
+Root cause suggestion:
+  New query in ProductService.findByCategory() introduced in commit c1f9823
+  → Run /db-index-advisor to find missing index
+```
+
+## Nightly Schedule (cron)
+
+```bash
+# Runs every night at 2am against staging
+0 2 * * * cd ~/app && k6 run load-tests/soak.js --out json=results/$(date +%Y%m%d).json
+```
+
+Pairs with `/load-test` skill for test design and script generation.

--- a/.claude/plugins/openapi-hub/.claude-plugin/plugin.json
+++ b/.claude/plugins/openapi-hub/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "openapi-hub",
+  "version": "1.0.0",
+  "description": "OpenAPI spec management hub. Maintains versioned API specs, validates specs on every commit, detects breaking changes between versions, generates typed clients (TypeScript, Python, Go), publishes developer documentation (Redoc/Swagger UI), and exports Postman collections. Enforces spec-first development workflow.",
+  "author": {
+    "name": "Anderson Lima",
+    "email": "andersonlimahw@gmail.com"
+  },
+  "keywords": ["openapi", "swagger", "rest-api", "api-docs", "spec-first", "breaking-changes", "sdk-generation", "redoc", "postman", "contract-testing"]
+}

--- a/.claude/plugins/openapi-hub/skills/openapi-hub.md
+++ b/.claude/plugins/openapi-hub/skills/openapi-hub.md
@@ -1,0 +1,59 @@
+---
+name: openapi-hub
+description: OpenAPI spec versioning, breaking change detection, and SDK publishing. Tracks spec versions, blocks PRs that introduce breaking API changes without a major version bump, and auto-publishes updated docs. Use when managing a public API, releasing a new API version, or detecting breaking changes in a PR.
+---
+
+# OpenAPI Hub Plugin
+
+Spec versioning + breaking change gates + SDK publishing.
+
+## Commands
+
+```
+/openapi-hub validate          — validate openapi.yaml against OpenAPI 3.1
+/openapi-hub diff v1 v2        — detect breaking changes between versions
+/openapi-hub publish           — publish docs to Redoc / GitHub Pages
+/openapi-hub sdk ts            — regenerate TypeScript SDK from current spec
+/openapi-hub changelog         — auto-generate API changelog from spec diff
+/openapi-hub mock-server       — start Prism mock server from spec
+```
+
+## Breaking Change Detection
+
+```
+BREAKING CHANGES — v3.3.0 → v3.4.0
+=====================================
+❌ 2 breaking changes detected (requires major version bump)
+
+  [BREAK] GET /products/{id} — removed field 'legacyId' from response
+          → Clients depending on legacyId will break silently
+          → Add to deprecated fields list and keep for v4.0.0
+
+  [BREAK] POST /orders — 'couponCode' now required (was optional)
+          → Clients not sending couponCode will get 422
+          → Make it optional again OR bump to v4.0.0
+
+⚠️ 3 non-breaking changes (safe to ship in v3.4.0)
+  [ADD] GET /products — new optional query param 'featured'
+  [ADD] User schema — new optional field 'avatarUrl'
+  [DEP] POST /v1/auth/login — deprecated, use POST /v2/auth/login
+```
+
+## Spec Versioning
+
+```
+specs/
+  openapi.yaml          ← current (auto-symlink to latest)
+  openapi-v3.4.0.yaml
+  openapi-v3.3.0.yaml
+  openapi-v3.2.0.yaml
+```
+
+## CI Gate
+
+```yaml
+- name: Detect breaking API changes
+  run: npx @redocly/cli lint openapi.yaml && npx oasdiff openapi-v3.3.0.yaml openapi.yaml --fail-on-breaking
+```
+
+Pairs with `/openapi-generate` skill for spec generation.

--- a/.claude/skills/a11y-audit/SKILL.md
+++ b/.claude/skills/a11y-audit/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: a11y-audit
+description: WCAG 2.1 AA/AAA accessibility audit for web components, pages, and apps. Detects contrast failures, missing ARIA labels, keyboard trap issues, focus order problems, and screen-reader gotchas. Use when user wants to audit accessibility, fix a11y warnings, prepare for compliance review, or validate UI against WCAG standards.
+---
+
+# Accessibility Audit (a11y)
+
+WCAG 2.1 AA/AAA audit — find and fix accessibility issues before they block users or compliance.
+
+## Quick Start
+
+```
+/a11y-audit                    — full page audit (reads current UI files)
+/a11y-audit --component Button — audit single component
+/a11y-audit --wcag AAA         — strict AAA audit
+/a11y-audit --fix              — audit + auto-apply safe fixes
+/a11y-audit --report           — generate HTML accessibility report
+```
+
+## What Gets Audited
+
+### 1. Perceivable
+- **1.1.1** Non-text content: all `<img>`, `<svg>`, `<canvas>` have meaningful `alt` / `aria-label`
+- **1.3.1** Info and relationships: semantic HTML structure (headings, lists, tables)
+- **1.4.3** Contrast ratio: text ≥ 4.5:1 (normal) or ≥ 3:1 (large text / UI components)
+- **1.4.4** Resize text: layout survives 200% browser zoom
+
+### 2. Operable
+- **2.1.1** Keyboard accessible: all interactive elements reachable via Tab / Enter / Space
+- **2.1.2** No keyboard trap: Esc always escapes modals, dialogs, and popovers
+- **2.4.3** Focus order: Tab sequence follows visual reading order
+- **2.4.7** Focus visible: focus ring visible on all interactive elements
+
+### 3. Understandable
+- **3.1.1** Language of page: `<html lang="...">` present and correct
+- **3.3.1** Error identification: form errors describe what went wrong + how to fix
+- **3.3.2** Labels or instructions: all inputs have `<label>` or `aria-labelledby`
+
+### 4. Robust
+- **4.1.2** Name, role, value: custom components expose correct ARIA roles and states
+- **4.1.3** Status messages: toasts and alerts use `role="alert"` or `aria-live`
+
+## Workflow
+
+Claude will:
+1. Scan component files for a11y violations (static analysis)
+2. Check color variables against contrast ratio thresholds
+3. Validate ARIA role/state usage
+4. Check keyboard interaction patterns
+5. Produce severity-ranked findings (CRITICAL / HIGH / MEDIUM / LOW)
+6. With `--fix`: apply non-breaking fixes (add `alt=""`, `aria-label`, `lang`, focus styles)
+
+## Output Format
+
+```
+A11Y AUDIT REPORT — 2026-06-14
+================================
+SCORE: 68/100   WCAG 2.1 AA
+
+CRITICAL (blocks WCAG compliance)
+  [C1] src/Button.tsx:12 — Interactive element has no accessible name
+       → Add aria-label="Close dialog" or visible text content
+  [C2] src/Card.tsx:8  — Contrast ratio 2.1:1 (required: 4.5:1)
+       → Change text from #9ca3af → #6b7280 (ratio 4.6:1)
+
+HIGH (fails WCAG AA)
+  [H1] src/Modal.tsx:45 — No focus trap in modal
+       → Use focus-trap-react or implement manual Tab/Shift+Tab containment
+  [H2] src/Form.tsx:23  — Input has no associated label
+       → Add <label htmlFor="email"> or aria-labelledby
+
+MEDIUM
+  [M1] src/Nav.tsx:5  — Missing skip-to-content link
+       → Add <a href="#main" className="skip-link">Skip to content</a>
+```
+
+## Common Fixes
+
+### Missing alt text
+```tsx
+// ❌
+<img src="/hero.png" />
+// ✅ decorative
+<img src="/hero.png" alt="" />
+// ✅ meaningful
+<img src="/avatar.png" alt="Profile photo of Jane Doe" />
+```
+
+### Focus visible
+```css
+/* ❌ never do this */
+:focus { outline: none; }
+/* ✅ */
+:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+```
+
+### ARIA live regions
+```tsx
+// ❌ toast appears but screen readers don't announce
+<Toast>{message}</Toast>
+// ✅
+<div role="alert" aria-live="polite">{message}</div>
+```
+
+## Tools Referenced
+
+- axe-core (static analysis basis)
+- WCAG 2.1 guidelines: https://www.w3.org/WAI/WCAG21/quickref/
+- Color contrast: APCA algorithm for large text

--- a/.claude/skills/async-patterns/SKILL.md
+++ b/.claude/skills/async-patterns/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: async-patterns
+description: Async and concurrency pattern advisor for JavaScript/TypeScript, Python, Go, and Rust. Identifies race conditions, missing error handling in promise chains, N+1 async anti-patterns, unbounded parallelism, and missing cancellation. Recommends correct patterns: Promise.all, p-limit, AbortController, AsyncLocalStorage, worker threads. Use when async code has bugs, timeouts, or memory leaks.
+---
+
+# Async Patterns
+
+Correct async code is hard. This skill finds the bugs and shows the fix.
+
+## Quick Start
+
+```
+/async-patterns                   — audit current codebase async patterns
+/async-patterns --file src/api.ts — analyze single file
+/async-patterns --race-conditions — focus on race condition detection
+/async-patterns --fix             — apply safe pattern upgrades
+```
+
+## Common Anti-Patterns and Fixes
+
+### 1. Sequential instead of parallel (N+1 async)
+```typescript
+// ❌ 100 users × 50ms each = 5,000ms
+for (const userId of userIds) {
+  const user = await db.user.findById(userId)
+  users.push(user)
+}
+
+// ✅ all in parallel = ~50ms
+const users = await Promise.all(userIds.map(id => db.user.findById(id)))
+
+// ✅ with concurrency limit (avoid overwhelming DB)
+import pLimit from 'p-limit'
+const limit = pLimit(10)
+const users = await Promise.all(userIds.map(id => limit(() => db.user.findById(id))))
+```
+
+### 2. Swallowed promise rejections
+```typescript
+// ❌ fire and forget — errors silently disappear
+sendEmail(user).catch(() => {}) // hiding the error
+doSomething() // no await, no catch
+
+// ✅ explicit non-critical handling
+sendEmail(user).catch(err => logger.warn('Email failed, non-critical', { err }))
+
+// ✅ or make it explicit you don't care (and document why)
+void sendAnalytics(event) // non-critical telemetry, intentional fire-and-forget
+```
+
+### 3. Missing AbortController (uncancellable fetches)
+```typescript
+// ❌ fetch keeps running even if component unmounts / request times out
+useEffect(() => {
+  fetch('/api/data').then(r => r.json()).then(setData)
+}, [])
+
+// ✅ cancellable with timeout
+useEffect(() => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 5000)
+
+  fetch('/api/data', { signal: controller.signal })
+    .then(r => r.json())
+    .then(setData)
+    .catch(err => { if (err.name !== 'AbortError') setError(err) })
+    .finally(() => clearTimeout(timer))
+
+  return () => controller.abort()
+}, [])
+```
+
+### 4. Race condition in state updates
+```typescript
+// ❌ if user types fast, older response can overwrite newer one
+const [data, setData] = useState(null)
+async function search(query: string) {
+  const result = await fetch(`/api/search?q=${query}`)
+  setData(await result.json()) // stale response can arrive last
+}
+
+// ✅ ignore stale responses with version counter
+const requestId = useRef(0)
+async function search(query: string) {
+  const id = ++requestId.current
+  const result = await fetch(`/api/search?q=${query}`)
+  if (id === requestId.current) setData(await result.json())
+}
+```
+
+### 5. Unbound parallelism (memory/connection exhaustion)
+```typescript
+// ❌ spawns 10,000 concurrent DB connections
+await Promise.all(records.map(r => processRecord(r)))
+
+// ✅ bounded concurrency
+import pLimit from 'p-limit'
+const limit = pLimit(20)
+await Promise.all(records.map(r => limit(() => processRecord(r))))
+```
+
+### 6. Missing error boundary in Promise.all
+```typescript
+// ❌ one failure rejects all — you lose partial results
+const [users, orders, products] = await Promise.all([
+  getUsers(),
+  getOrders(),
+  getProducts(),
+])
+
+// ✅ use Promise.allSettled when partial results are acceptable
+const results = await Promise.allSettled([getUsers(), getOrders(), getProducts()])
+const [users, orders, products] = results.map(r =>
+  r.status === 'fulfilled' ? r.value : null
+)
+```
+
+### 7. Mutex for shared mutable state (Node.js)
+```typescript
+// ❌ two concurrent requests can read same balance, both deduct, overdraft
+async function deductBalance(userId: string, amount: number) {
+  const user = await db.user.findById(userId)
+  if (user.balance < amount) throw new Error('Insufficient funds')
+  await db.user.update(userId, { balance: user.balance - amount })
+}
+
+// ✅ database-level atomic update
+await db.user.updateMany({
+  where: { id: userId, balance: { gte: amount } },
+  data: { balance: { decrement: amount } },
+})
+// Check affected count — 0 means insufficient funds
+```
+
+### 8. Context propagation (AsyncLocalStorage)
+```typescript
+// Share request context across async calls without prop drilling
+import { AsyncLocalStorage } from 'async_hooks'
+
+const requestContext = new AsyncLocalStorage<{ requestId: string; userId: string }>()
+
+// Middleware
+app.use((req, res, next) => {
+  requestContext.run({ requestId: req.id, userId: req.user?.id }, next)
+})
+
+// Anywhere in the call chain
+function logEvent(event: string) {
+  const ctx = requestContext.getStore()
+  logger.info(event, { requestId: ctx?.requestId })
+}
+```
+
+## Audit Output
+
+```
+ASYNC AUDIT — 2026-06-14
+==========================
+Files analyzed: 34  |  Issues: 12
+
+CRITICAL
+  [C1] src/api/reports.ts:45 — UNBOUNDED PARALLELISM
+       Promise.all over reportIds (up to 5,000 items)
+       → Wrap with pLimit(20)
+
+  [C2] src/hooks/useSearch.ts:23 — RACE CONDITION
+       Stale response can overwrite latest result
+       → Add requestId counter or use AbortController
+
+HIGH
+  [H1] src/workers/emailQueue.ts — SWALLOWED REJECTION
+       sendEmail().catch(() => {}) — errors lost silently
+       → Log and retry or push to dead-letter queue
+
+MEDIUM
+  [M1] src/api/users.ts:67 — SEQUENTIAL N+1
+       for...await loop over 50 users
+       → Promise.all with pLimit(10)
+```

--- a/.claude/skills/bundle-analyzer/SKILL.md
+++ b/.claude/skills/bundle-analyzer/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: bundle-analyzer
+description: JavaScript/TypeScript bundle size analysis, tree-shaking audit, and code splitting recommendations. Identifies heavy dependencies, duplicate packages, unused imports, and suggests dynamic imports and lazy loading. Use when bundle is too large, Lighthouse score is low, or user wants to optimize web app loading performance.
+---
+
+# Bundle Analyzer
+
+Cut your JS bundle. Faster page loads, better Core Web Vitals.
+
+## Quick Start
+
+```
+/bundle-analyzer                  — analyze current project bundle
+/bundle-analyzer --why lodash     — trace why a dep is included
+/bundle-analyzer --alternatives   — find lighter alternatives to heavy deps
+/bundle-analyzer --budget 200kb   — check against size budget
+/bundle-analyzer --diff           — compare bundle size before/after change
+```
+
+## What Gets Analyzed
+
+- **Total bundle size** (gzipped vs raw)
+- **Chunk composition** (which routes include what)
+- **Duplicate packages** (same lib at different versions)
+- **Side-effect imports** (prevents tree-shaking)
+- **Dynamic import opportunities** (code-split candidates)
+- **Unused exports** (dead exports still in bundle)
+- **Heavy dependencies** (sorted by size contribution)
+
+## Workflow
+
+Claude will:
+1. Run `npx vite-bundle-visualizer` / `npx @next/bundle-analyzer` / `npx webpack-bundle-analyzer`
+2. Parse stats JSON
+3. List top 20 largest modules
+4. Identify duplicate packages (e.g., lodash + lodash-es)
+5. Flag non-tree-shakeable side-effect imports
+6. Detect unneeded full library imports (`import _ from 'lodash'`)
+7. Recommend: dynamic imports, lighter alternatives, CDN externals
+
+## Output Format
+
+```
+BUNDLE ANALYSIS — 2026-06-14
+==============================
+Total:  1.24 MB raw  |  342 KB gzip
+Budget: 200 KB gzip  ❌ (over by 142 KB)
+
+TOP MODULES BY SIZE
+  moment.js          94 KB  ← replace with date-fns (tree-shakeable)
+  lodash             72 KB  ← import specific functions, not full bundle
+  @mui/icons-material 68 KB ← only 3 icons used; import individually
+  react-pdf          55 KB  ← load dynamically (only used in /reports)
+
+DUPLICATE PACKAGES
+  ⚠ react@18.2.0 + react@17.0.2 (from old-dep peer requirement)
+  ⚠ axios@0.27 + axios@1.4 (from two different SDKs)
+
+CODE SPLITTING OPPORTUNITIES
+  /admin dashboard — 180 KB (never shown to non-admins)
+  PDF generator    — 55 KB (used only on /reports route)
+  Charts           — 44 KB (used only on /analytics route)
+
+QUICK WINS (estimated savings: 210 KB gzip)
+  1. Replace moment.js → date-fns               → -61 KB
+  2. Use individual MUI icon imports             → -62 KB
+  3. Dynamic import for react-pdf               → -38 KB (deferred)
+  4. Deduplicate lodash versions                → -49 KB
+```
+
+## Common Fixes
+
+### Heavy library → lighter alternative
+
+| Replace | With | Savings |
+|---------|------|---------|
+| `moment` | `date-fns` or `dayjs` | ~90 KB |
+| `lodash` | Native ES6 methods | ~70 KB |
+| `axios` | `ky` or native `fetch` | ~40 KB |
+| `@mui/icons` (full) | Individual icon imports | ~60 KB |
+| `chart.js` | `uplot` or `lightweight-charts` | ~100 KB |
+
+### Dynamic import (code splitting)
+```typescript
+// ❌ always in bundle
+import { PDFViewer } from 'react-pdf'
+
+// ✅ only loaded when needed
+const PDFViewer = dynamic(() => import('react-pdf').then(m => m.PDFViewer), {
+  loading: () => <Spinner />,
+  ssr: false,
+})
+```
+
+### Tree-shakeable import
+```typescript
+// ❌ full lodash bundle
+import _ from 'lodash'
+const sorted = _.sortBy(arr, 'name')
+
+// ✅ only imports sortBy
+import sortBy from 'lodash/sortBy'
+const sorted = sortBy(arr, 'name')
+
+// ✅✅ native (zero bundle cost)
+const sorted = [...arr].sort((a, b) => a.name.localeCompare(b.name))
+```
+
+## Size Budgets (reference)
+
+| Page Type | Target (gzip) | Max (gzip) |
+|-----------|---------------|------------|
+| Landing page | <50 KB | 100 KB |
+| App shell | <100 KB | 200 KB |
+| Feature page | <50 KB incremental | 100 KB |
+| Admin/internal | <300 KB | 500 KB |

--- a/.claude/skills/chaos-test/SKILL.md
+++ b/.claude/skills/chaos-test/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: chaos-test
+description: Chaos engineering scenarios for resilience testing. Designs fault injection experiments (network partitions, latency injection, dependency failures, disk pressure, memory leaks) and verifies circuit breakers, retries, and fallbacks work correctly. Use when building resilience features, verifying SLO under failure conditions, or preparing for production chaos days.
+---
+
+# Chaos Test
+
+Deliberately break things to prove your system handles failure gracefully.
+
+## Quick Start
+
+```
+/chaos-test design              — design experiments for this codebase
+/chaos-test network-delay 500ms — inject network latency to dependencies
+/chaos-test kill-dep <service>  — simulate dependency outage
+/chaos-test memory-pressure     — simulate memory exhaustion
+/chaos-test verify-circuit      — verify circuit breakers work
+/chaos-test steady-state        — define and verify steady-state hypothesis
+```
+
+## Chaos Experiment Template
+
+Every experiment follows this structure:
+
+```
+Hypothesis: "When [condition], the system will [expected behavior]"
+Steady state: [metrics that define normal operation]
+Method: [what you will break]
+Rollback: [how to undo instantly]
+Success: [what proves the hypothesis]
+```
+
+## Common Experiments
+
+### 1. Dependency Outage
+```
+Hypothesis: When payment service is down, checkout shows friendly error
+            and no charges occur (idempotent)
+Steady state: checkout completion rate >95%, payment errors <0.1%
+Method: Block traffic to payment service (iptables / TC / mock)
+Rollback: Restore iptables rule
+Success: - Users see "Payment temporarily unavailable, try again"
+         - No partial charges in DB
+         - Circuit breaker opens after 5 failures
+         - Circuit closes after 30s (configurable)
+```
+
+### 2. High Latency Injection
+```
+Hypothesis: When DB queries take 2s, API still responds within 5s SLO
+            (no cascade timeout)
+Steady state: p95 API latency <500ms
+Method: Add 2s delay to DB connection (tc netem or toxiproxy)
+Rollback: Remove tc rule
+Success: - API p95 latency <5s (degraded but within SLO)
+         - No thread pool exhaustion
+         - Timeouts propagate, not hang
+```
+
+### 3. Memory Pressure
+```
+Hypothesis: When JVM/Node heap reaches 85%, GC kicks in and
+            service recovers without OOM crash
+Steady state: Memory <70%, p99 latency <1s
+Method: Allocate large in-memory object (stress-ng / custom script)
+Rollback: Kill stress process
+Success: - Memory returns to <70% after GC
+         - No process crash
+         - Error rate stays <1%
+```
+
+### 4. Pod/Process Kill
+```
+Hypothesis: Killing one pod causes zero user-visible errors
+            (health check + rolling deploy pattern)
+Steady state: HTTP 200 rate >99.9%
+Method: kubectl delete pod [random pod from deployment]
+Rollback: k8s auto-restarts; monitor for recovery
+Success: - Kubernetes replaces pod in <30s
+         - Zero HTTP errors during replacement
+         - Load balancer removes unhealthy pod before kill
+```
+
+## Toxiproxy Setup (network fault injection)
+
+```bash
+# Install
+brew install toxiproxy
+
+# Proxy your DB connection
+toxiproxy-cli create --listen localhost:5433 --upstream localhost:5432 db-proxy
+
+# Inject 500ms latency
+toxiproxy-cli toxic add db-proxy --type latency --attribute latency=500
+
+# Inject 10% packet loss
+toxiproxy-cli toxic add db-proxy --type bandwidth --attribute rate=100
+
+# Simulate timeout
+toxiproxy-cli toxic add db-proxy --type timeout --attribute timeout=0
+
+# Remove all toxics (recovery)
+toxiproxy-cli toxic remove db-proxy --toxicName latency_downstream
+```
+
+## Circuit Breaker Verification
+
+```typescript
+// What to verify
+[ ] Circuit opens after N failures (default: 5)
+[ ] Circuit stays open for M seconds (default: 30)
+[ ] Circuit moves to HALF-OPEN after timeout
+[ ] Single test request in HALF-OPEN state
+[ ] Circuit closes on first success in HALF-OPEN
+[ ] Fallback response is user-safe (not error 500)
+[ ] Metrics track open/close transitions
+```
+
+## Steady State Definition
+
+```yaml
+steady_state:
+  http_success_rate: ">= 99.5%"
+  p95_latency_ms: "<= 500"
+  error_rate: "<= 0.5%"
+  active_users_session_count: ">= 90% of baseline"
+  database_connection_pool: "<= 80% utilized"
+```
+
+## Chaos Calendar
+
+Recommended schedule:
+- Weekly: Kill a random pod in staging
+- Monthly: Dependency outage simulation in staging  
+- Quarterly: Game day — full chaos scenario with entire team
+- Annually: DR drill — full region failover

--- a/.claude/skills/code-smell/SKILL.md
+++ b/.claude/skills/code-smell/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: code-smell
+description: Code smell detection and remediation. Identifies long methods, god classes, feature envy, primitive obsession, shotgun surgery, dead code, magic numbers, and other structural anti-patterns. Goes beyond linters — understands semantic coupling and design intent. Use when code is hard to change, PRs are consistently risky, or technical debt is growing faster than features.
+---
+
+# Code Smell
+
+Find structural problems before they calcify into permanent pain.
+
+## Quick Start
+
+```
+/code-smell                     — full codebase smell analysis
+/code-smell --file src/user.ts  — analyze single file
+/code-smell --category god-class — hunt specific smell type
+/code-smell --fix               — apply safe refactors (extract method, rename)
+/code-smell --rank              — sort files by smell density
+```
+
+## Smell Catalog
+
+### Bloaters (things that grew too big)
+| Smell | Signal | Fix |
+|-------|--------|-----|
+| **Long Method** | >20 lines, multiple levels of abstraction | Extract Method |
+| **Large Class** | >300 lines, too many responsibilities | Extract Class / SRP |
+| **Long Parameter List** | >4 params | Introduce Parameter Object |
+| **Data Clumps** | Same 3+ vars always appear together | Extract Class |
+| **Primitive Obsession** | `string` for email/money/status | Value Object |
+
+### OO Abusers
+| Smell | Signal | Fix |
+|-------|--------|-----|
+| **Switch Statements** | Switch/if-chain on type | Polymorphism |
+| **Temporary Field** | Field only set in one method | Extract Class |
+| **Refused Bequest** | Child ignores most of parent | Replace Inheritance with Delegation |
+| **Alternative Classes** | Two classes do the same thing | Merge |
+
+### Change Preventers
+| Smell | Signal | Fix |
+|-------|--------|-----|
+| **Divergent Change** | Changing feature X always touches Class Y | Split class |
+| **Shotgun Surgery** | One change → 8 files | Move Method / Inline Class |
+| **Parallel Inheritance** | Adding subclass A requires subclass B | Merge hierarchies |
+
+### Dispensables (things to delete)
+| Smell | Signal | Fix |
+|-------|--------|-----|
+| **Dead Code** | Unreachable / never called | Delete |
+| **Speculative Generality** | `AbstractFactory` for one use case | Simplify |
+| **Lazy Class** | Class does almost nothing | Inline Class |
+| **Duplicate Code** | Copy-paste across files | Extract + reuse |
+
+### Couplers
+| Smell | Signal | Fix |
+|-------|--------|-----|
+| **Feature Envy** | Method uses other class's data more than own | Move Method |
+| **Inappropriate Intimacy** | Two classes read each other's privates | Move / Extract |
+| **Message Chains** | `a.b().c().d().e()` | Introduce delegate method |
+| **Middle Man** | Class delegates everything to another | Inline Class |
+
+## Output Format
+
+```
+CODE SMELL ANALYSIS — 2026-06-14
+===================================
+Files analyzed: 147  |  Smell density: 2.3 smells/100 lines (HIGH)
+
+CRITICAL
+  [C1] src/services/UserService.ts — GOD CLASS (847 lines, 23 methods)
+       Handles: auth, profile, billing, notifications, admin, analytics
+       → Extract: AuthService, BillingService, NotificationService
+       Estimated effort: 2 days | Risk: HIGH (many callers)
+
+  [C2] src/api/checkout.ts:145 — LONG METHOD (94 lines, 7 abstraction levels)
+       → Extract: validateCart(), applyDiscounts(), chargePayment(), sendConfirmation()
+
+HIGH
+  [H1] src/models/Product.ts:12 — PRIMITIVE OBSESSION
+       price: number (no currency, no precision)
+       → type Money = { amount: number; currency: Currency }
+
+  [H2] src/components/AdminPanel.tsx — FEATURE ENVY
+       References user.subscription.plan.features 14 times
+       → Move canAccessFeature(featureId) to User or Subscription model
+
+MEDIUM
+  [M1] src/utils/helpers.ts — DEAD CODE (3 exported functions, 0 callers)
+       formatLegacyDate(), parseOldSKU(), migrateV1User()
+       → Safe to delete (confirmed by grep + git log)
+
+  [M2] src/api/ — DUPLICATE CODE
+       validateEmail() defined in auth.ts, users.ts, and checkout.ts
+       → Extract to src/utils/validation.ts
+
+LOW
+  [L1] 12 occurrences of magic numbers (HTTP status codes, timeout values)
+       → Extract to src/constants/http.ts and src/config/timeouts.ts
+```
+
+## Safe Refactor Patterns
+
+### Extract Method
+```typescript
+// ❌ 60-line method
+async processOrder(cart: Cart, user: User) {
+  // validate cart
+  if (!cart.items.length) throw new Error('Empty cart')
+  const inventory = await this.checkInventory(cart.items)
+  // ... 50 more lines
+}
+
+// ✅ decomposed
+async processOrder(cart: Cart, user: User) {
+  await this.validateCart(cart)
+  const payment = await this.chargePayment(cart, user)
+  await this.fulfillOrder(cart, payment)
+  await this.sendConfirmation(user, payment)
+}
+```
+
+### Introduce Value Object
+```typescript
+// ❌ primitive obsession
+function charge(amount: number, currency: string) { ... }
+
+// ✅ value object
+class Money {
+  constructor(readonly amount: number, readonly currency: 'USD' | 'BRL' | 'EUR') {}
+  plus(other: Money): Money {
+    if (this.currency !== other.currency) throw new Error('Currency mismatch')
+    return new Money(this.amount + other.amount, this.currency)
+  }
+}
+```
+
+### Replace Switch with Map
+```typescript
+// ❌ switch smells
+function getDiscount(tier: string): number {
+  switch (tier) {
+    case 'bronze': return 0.05
+    case 'silver': return 0.10
+    case 'gold': return 0.20
+    default: return 0
+  }
+}
+
+// ✅ data-driven
+const DISCOUNTS: Record<string, number> = { bronze: 0.05, silver: 0.10, gold: 0.20 }
+const getDiscount = (tier: string) => DISCOUNTS[tier] ?? 0
+```

--- a/.claude/skills/db-index-advisor/SKILL.md
+++ b/.claude/skills/db-index-advisor/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: db-index-advisor
+description: Database index optimization advisor for PostgreSQL, MySQL, and SQLite. Analyzes slow queries, missing indexes, unused indexes, and over-indexed tables. Generates CREATE INDEX statements with EXPLAIN ANALYZE estimates. Use when queries are slow, p99 DB latency spikes, or when reviewing a new schema.
+---
+
+# DB Index Advisor
+
+Find slow queries. Add the right indexes. Drop the useless ones.
+
+## Quick Start
+
+```
+/db-index-advisor                     — analyze current ORM queries + schema
+/db-index-advisor --slow-log          — parse slow query log
+/db-index-advisor --query "SELECT..." — analyze specific query
+/db-index-advisor --table orders      — focus on one table
+/db-index-advisor --unused            — find indexes that cost writes but never help reads
+```
+
+## Workflow
+
+Claude will:
+1. Read schema (migration files / ORM models / schema.prisma)
+2. Read query patterns (repository files, ORM queries, raw SQL)
+3. Identify sequential scans on large tables
+4. Generate `EXPLAIN (ANALYZE, BUFFERS)` commands
+5. Suggest indexes ranked by estimated impact
+6. Flag redundant and unused indexes
+7. Warn about index maintenance cost on write-heavy tables
+
+## Common Index Patterns
+
+### Single column (equality)
+```sql
+-- Query: WHERE user_id = $1
+CREATE INDEX idx_orders_user_id ON orders(user_id);
+```
+
+### Composite (equality + sort)
+```sql
+-- Query: WHERE user_id = $1 ORDER BY created_at DESC
+-- ❌ Two separate indexes won't help as much
+-- ✅ Composite covers both
+CREATE INDEX idx_orders_user_created
+  ON orders(user_id, created_at DESC);
+```
+
+### Partial index (filter on subset)
+```sql
+-- Query: WHERE status = 'pending' AND created_at > NOW() - INTERVAL '7 days'
+-- Full index on status wastes space (99% rows are 'completed')
+CREATE INDEX idx_orders_pending
+  ON orders(created_at DESC)
+  WHERE status = 'pending';
+```
+
+### Covering index (avoid heap fetch)
+```sql
+-- Query: SELECT id, total FROM orders WHERE user_id = $1
+-- Covering index returns result from index alone (no table lookup)
+CREATE INDEX idx_orders_user_covering
+  ON orders(user_id) INCLUDE (id, total);
+```
+
+### Full-text search
+```sql
+-- Query: WHERE description ILIKE '%payment%'
+-- ❌ ILIKE uses sequential scan
+-- ✅ GIN index for full-text
+CREATE INDEX idx_products_search
+  ON products USING gin(to_tsvector('english', description));
+-- Query becomes:
+-- WHERE to_tsvector('english', description) @@ plainto_tsquery('payment')
+```
+
+### JSON/JSONB field
+```sql
+-- Query: WHERE metadata->>'plan' = 'pro'
+CREATE INDEX idx_users_plan
+  ON users((metadata->>'plan'));
+```
+
+## Output Format
+
+```
+DB INDEX ANALYSIS — 2026-06-14
+================================
+Schema: PostgreSQL 15  |  Tables analyzed: 12  |  Queries analyzed: 34
+
+CRITICAL — Sequential scans on large tables
+  [C1] orders table (2.1M rows)
+       Query: SELECT * FROM orders WHERE user_id = $1 ORDER BY created_at DESC
+       Cost: seq_scan ~480ms → with index ~1.2ms (400× faster)
+       → CREATE INDEX idx_orders_user_created ON orders(user_id, created_at DESC);
+
+  [C2] events table (8.4M rows)
+       Query: WHERE type = 'click' AND session_id = $1
+       Cost: seq_scan ~1,800ms → with partial index ~3ms
+       → CREATE INDEX idx_events_click_session
+           ON events(session_id)
+           WHERE type = 'click';
+
+HIGH — Missing FK indexes (causes slow JOINs)
+  [H1] order_items.product_id — no index, causes nested loop on every JOIN
+
+MEDIUM — Redundant indexes (waste write performance)
+  [M1] idx_orders_user + idx_orders_user_id — duplicate; drop idx_orders_user
+
+LOW — Unused indexes (last used > 30 days ago per pg_stat_user_indexes)
+  [L1] idx_users_phone — 0 scans in 90 days; created 2024-01 for SMS feature
+  [L2] idx_products_legacy_sku — 0 scans; SKU format changed
+
+GENERATED SQL
+  -- Apply in this order (low-risk first):
+  CREATE INDEX CONCURRENTLY idx_orders_user_created ON orders(user_id, created_at DESC);
+  CREATE INDEX CONCURRENTLY idx_order_items_product_id ON order_items(product_id);
+  DROP INDEX CONCURRENTLY idx_users_phone;
+```
+
+## Safety Rules
+
+- Always use `CREATE INDEX CONCURRENTLY` on live tables (no table lock)
+- Add indexes during low-traffic windows for very large tables
+- Monitor `pg_stat_progress_create_index` during creation
+- `EXPLAIN ANALYZE` before + after to confirm improvement
+- Don't index columns with <10 distinct values (e.g., boolean, status with 2 values)
+- Every index slows INSERT/UPDATE/DELETE — don't over-index write-heavy tables
+
+## Prisma / TypeORM / Drizzle Integration
+
+```typescript
+// Prisma — add index to schema.prisma
+model Order {
+  @@index([userId, createdAt(sort: Desc)])
+}
+
+// TypeORM
+@Index(['userId', 'createdAt'])
+@Entity()
+class Order { ... }
+
+// Drizzle
+const orders = pgTable('orders', { ... }, (table) => ({
+  userCreatedIdx: index('idx_orders_user_created')
+    .on(table.userId, table.createdAt),
+}))
+```

--- a/.claude/skills/feature-flag/SKILL.md
+++ b/.claude/skills/feature-flag/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: feature-flag
+description: Feature flag implementation, management, and cleanup. Handles flag creation, gradual rollout strategies, A/B testing wiring, stale flag detection, and safe flag removal. Supports LaunchDarkly, Unleash, GrowthBook, Statsig, custom env-var flags, and database-backed toggles. Use when adding gated features, rolling out gradually, or cleaning up old flags.
+---
+
+# Feature Flag
+
+Implement, manage, and retire feature flags safely across any stack.
+
+## Quick Start
+
+```
+/feature-flag add <name>           — scaffold a new flag
+/feature-flag rollout <name> 10%   — set gradual rollout percentage
+/feature-flag audit                — find all flags + flag staleness
+/feature-flag remove <name>        — safe removal with dead-code cleanup
+/feature-flag list                 — show all flags and current state
+```
+
+## Flag Types
+
+| Type | When to Use |
+|------|-------------|
+| **Kill switch** | Turn off broken feature instantly in prod |
+| **Release gate** | Ship code dark, enable when ready |
+| **Gradual rollout** | 1% → 10% → 50% → 100% |
+| **A/B experiment** | Split traffic, measure variant metrics |
+| **User segment** | Beta users, internal users, region-specific |
+
+## Workflow
+
+### Add New Flag
+Claude will:
+1. Name-check (format: `snake_case`, category prefix: `feat_`, `exp_`, `ops_`)
+2. Create flag definition in chosen provider or local config
+3. Scaffold flag-gated code with proper `if/else` fallback
+4. Add cleanup TODO with target removal date
+5. Add to flag registry / CLAUDE.md
+
+### Gradual Rollout
+```
+/feature-flag rollout feat_new_checkout 10%
+/feature-flag rollout feat_new_checkout 50%
+/feature-flag rollout feat_new_checkout 100%
+/feature-flag promote feat_new_checkout    — remove flag, keep code
+```
+
+### Audit Stale Flags
+Finds flags that:
+- Are 100% enabled and have no A/B experiment
+- Were last modified > 90 days ago
+- Control code paths never hit in production
+
+## Code Patterns
+
+### Environment variable (simplest)
+```typescript
+// flag-registry.ts
+export const FLAGS = {
+  NEW_CHECKOUT: process.env.FLAG_NEW_CHECKOUT === 'true',
+  DARK_MODE_V2: process.env.FLAG_DARK_MODE_V2 === 'true',
+} as const
+
+// usage
+if (FLAGS.NEW_CHECKOUT) {
+  return <NewCheckout />
+}
+return <OldCheckout />
+```
+
+### LaunchDarkly
+```typescript
+import { LDClient } from '@launchdarkly/node-server-sdk'
+
+const flag = await client.variation('feat-new-checkout', user, false)
+if (flag) { ... }
+```
+
+### GrowthBook
+```typescript
+const gb = new GrowthBook({ features })
+if (gb.isOn('feat-new-checkout')) { ... }
+```
+
+### Database-backed (custom)
+```sql
+-- flags table
+CREATE TABLE feature_flags (
+  key        TEXT PRIMARY KEY,
+  enabled    BOOLEAN DEFAULT false,
+  rollout_pct INT DEFAULT 0,
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+## Safe Flag Removal Checklist
+
+```
+[ ] Flag is 100% enabled in all environments
+[ ] No A/B experiment data still being collected
+[ ] Metrics confirmed (conversion, error rate, latency)
+[ ] Remove flag check from code (keep the new path)
+[ ] Delete flag from provider / config
+[ ] Delete tests that mock the disabled path
+[ ] Update changelog
+```
+
+## Naming Conventions
+
+```
+feat_<feature>          — user-facing feature gate
+exp_<hypothesis>        — A/B experiment
+ops_<operation>         — operational kill switch
+tmp_<migration>         — temporary migration flag (max 30 days)
+```
+
+## Anti-Patterns
+
+- Nesting flags inside flags (creates truth table hell)
+- Flags with no owner or target removal date
+- Testing only the enabled path (always test both)
+- Keeping flags after 100% rollout > 2 weeks

--- a/.claude/skills/feature-purge/SKILL.md
+++ b/.claude/skills/feature-purge/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: feature-purge
+description: Safely remove an entire feature and every dead reference it leaves behind — not just the folder you point at, but the sibling folders in other architecture layers, the imports/registries/routes/i18n keys that point to it, and any newly-orphaned code. Verifies the quality gate stays 100% green and writes a Markdown removal report. Use when deleting a feature, screen, module, or directory and you need it gone WITHOUT leaving dead files or dead code. Triggers on /feature-purge <path>, "remove this feature", "delete this folder safely", "apaga essa feature sem deixar código morto", "limpa essa screen e as camadas".
+---
+
+# Feature Purge
+
+Delete a feature for real. You give it one path; it finds the rest of the feature across the codebase, removes it, cleans every reference, and proves the quality gate is still green.
+
+The danger this skill exists to kill: you delete `screens/Bets/` but leave `usecases/bets/`, the repository impl, the navigation route, the barrel `export *`, and 12 `import { Bets } from ...` lines — half-dead feature, red build, ghost code.
+
+## Invocation
+
+```
+/feature-purge <path> [<path2> ...]
+```
+
+`<path>` is the primary folder/file to remove (usually the most visible one — a screen, a module). The skill derives the **feature slug** from it (folder name, normalized: `Bets` → `bets`/`Bets`) and uses that slug to discover the rest.
+
+## Workflow (do in order, do not skip)
+
+### 1. Scope — derive slug + map the primary target
+- Resolve the path. Confirm it exists and is inside the repo.
+- Derive `slug` from the leaf name. Keep both casings (`Bets`, `bets`) and obvious variants (`bet`, `betting`) — list them, you'll grep for all.
+- List the primary target's files (these are the **main removals**).
+
+### 2. Discover sibling targets across layers (the whole point)
+Most codebases split one feature across parallel directories (layers, packages, test mirrors). Find the siblings by slug:
+- Detect the project's layering from the path. Generic heuristic: take the repo's top source roots (e.g. `src/`, `app/`, `lib/`, `packages/*`, `test/`, `__tests__/`) and look for any directory or file whose name matches the slug under each root.
+- Typical siblings: business logic, data/repository, domain/model, infrastructure, state/store, hooks, types, tests, fixtures, styles.
+- Build a **candidate list**. Mark each `confident` (name is an exact slug match in a recognized layer) or `maybe` (fuzzy / shared dir).
+
+### 3. Ask before the deep sweep
+The slug match finds folders. It does NOT find scattered references (a single `import`, a route string, an i18n key, a feature-flag entry). Those need a repo-wide grep that is slower and noisier.
+
+Use **AskUserQuestion** to confirm scope before the expensive search:
+- Question: run the deep reference sweep (grep the whole repo for the slug + import paths)?
+- Options: **Yes — full sweep (recommended)** / Targeted only (just the listed folders) / Let me edit the target list first.
+
+If the user already said "be thorough" / "remove everything", skip the question and do the full sweep.
+
+### 4. Find references (orphan hunt)
+For every file about to be removed, grep the repo for things that point at it:
+- `import` / `require` / re-export (`export * from`, barrel `index` files).
+- Registry/DI wiring (a container that binds the repository, a `useCases` map).
+- Navigation routes / deep links / route-name constants.
+- i18n keys namespaced under the slug.
+- Feature flags, config entries, menu/tab definitions referencing it.
+Record each as a **reference to clean** with file + line.
+
+### 5. Confirm the plan, then execute
+Print the plan: main removals · sibling removals · references to clean. Then:
+- Delete folders/files (`rm`/`git rm`).
+- In each referencing file, surgically remove ONLY the orphaned lines (the import, the route entry, the barrel re-export, the i18n key). Do not refactor adjacent code (Karpathy surgical rule).
+- After removing imports, remove anything those removals just orphaned (now-unused local imports/vars) — but only what YOUR change orphaned.
+
+### 6. Quality gate — must end 100% green
+Run the project's gate (typecheck / lint / i18n check / tests / build — whatever the repo has). If anything fails because a reference was missed, fix it and re-run. Loop until green. Never finish red.
+
+### 7. Write the report
+Write `feature-purge-<slug>-<YYYY-MM-DD>.md` (in the repo's docs/reports dir if one exists, else repo root). Use the template below.
+
+## Report template
+
+```markdown
+# Feature Purge — <slug>
+
+Date: <YYYY-MM-DD> · Invoked with: `<paths>`
+
+## Removed — primary
+- <path/file>  (N files)
+
+## Removed — related (other layers)
+- <path/file>  — <layer> — confident|maybe
+
+## Modified — references cleaned
+- <file>:<line> — removed <import|route|barrel export|i18n key|DI binding>
+
+## Quality gate
+- typecheck: ✅ | lint: ✅ | i18n: ✅ | tests: ✅ (<n> passed) | build: ✅
+
+## Notes
+- <anything skipped, any `maybe` left in place and why>
+```
+
+## Rules
+- One path in, whole feature out. Always look for siblings in other layers — that is the core value.
+- Ask before the repo-wide sweep unless the user opted into thoroughness.
+- Surgical: every line you touch traces to removing this feature. No drive-by refactors.
+- Never leave the gate red. If you cannot make it green, stop and report what blocks it instead of deleting more.
+- Optimized: derive the slug once, grep once per scope, fix-and-recheck only the failing gate step.

--- a/.claude/skills/git-bisect-ai/SKILL.md
+++ b/.claude/skills/git-bisect-ai/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: git-bisect-ai
+description: AI-guided git bisect for finding the exact commit that introduced a bug or regression. Automates the binary search, interprets test results, and identifies the responsible code change with full context. Use when you know a bug exists now but didn't exist before, or when a performance regression appeared somewhere in git history.
+---
+
+# Git Bisect AI
+
+Find the commit that broke it — without reading 500 commits manually.
+
+## Quick Start
+
+```
+/git-bisect-ai                          — interactive bisect session
+/git-bisect-ai --auto "npm test"        — fully automated with test command
+/git-bisect-ai --good v2.1.0 --bad HEAD — specify known good/bad points
+/git-bisect-ai --perf "p99 latency"    — performance regression bisect
+```
+
+## How It Works
+
+Binary search through commits: `O(log n)` — 1000 commits = ~10 steps.
+
+Claude will:
+1. Ask for symptom + known good commit (or tag)
+2. Run `git bisect start`
+3. At each step: checkout commit → run test/check → mark good/bad
+4. Identify the culprit commit
+5. Explain what changed and why it likely caused the regression
+6. Suggest targeted fix or revert strategy
+
+## Workflow
+
+### Interactive Mode
+```
+/git-bisect-ai
+
+Claude: What's the regression?
+You: The /checkout page returns 500 after a database query
+
+Claude: When did it last work?
+You: It was fine in the v3.2.0 release
+
+Claude will:
+  git bisect start
+  git bisect bad HEAD
+  git bisect good v3.2.0
+  → [steps through 8 commits]
+  → Found: commit abc1234
+     "feat: add discount coupon support"
+  → Changed: src/checkout/service.ts line 142
+     Added raw SQL interpolation (SQL injection + syntax error in some locales)
+```
+
+### Automated Mode (with test script)
+```bash
+git bisect start
+git bisect bad HEAD
+git bisect good v3.2.0
+
+# Claude generates and runs:
+git bisect run bash -c '
+  npm run build:quiet &&
+  curl -s -o /dev/null -w "%{http_code}" \
+    http://localhost:3000/api/checkout | grep -q 200
+'
+# Exits 0 = good, non-0 = bad
+```
+
+### Performance Regression Mode
+```bash
+/git-bisect-ai --perf
+
+Claude measures p95 latency at each bisect step:
+  Commit abc → p95: 95ms  (good)
+  Commit def → p95: 850ms (bad)
+  Commit ghi → p95: 102ms (good)
+  → Culprit: commit def
+     "refactor: extract UserService"
+     Introduced N+1 query in user.findByEmail()
+```
+
+## Bisect Script Templates
+
+### HTTP status check
+```bash
+git bisect run bash -c 'npm start &>/dev/null & sleep 3 && \
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/health) && \
+  kill %1 && [ "$STATUS" = "200" ]'
+```
+
+### Unit test
+```bash
+git bisect run npm test -- --testPathPattern="checkout.test.ts" --silent
+```
+
+### Build check
+```bash
+git bisect run npm run build 2>/dev/null
+```
+
+### Performance threshold
+```bash
+git bisect run bash -c '
+  npm start &>/dev/null & sleep 3 &&
+  LATENCY=$(curl -s -w "%{time_total}" -o /dev/null http://localhost:3000/api/products) &&
+  kill %1 &&
+  echo "$LATENCY < 0.5" | bc -l | grep -q 1
+'
+```
+
+## After Finding Culprit
+
+Claude will show:
+```
+BISECT RESULT
+==============
+Culprit commit: abc1234f
+Author: Jane Doe <jane@example.com>
+Date: 2026-06-10 14:32 UTC
+Message: "feat: add discount coupon support"
+
+CHANGED FILES
+  src/checkout/service.ts    (+47, -12)
+  src/models/coupon.ts       (+120, -0)  ← NEW FILE
+
+ROOT CAUSE (line 142 in service.ts)
+  const query = `SELECT * FROM orders WHERE code = '${couponCode}'`
+  ← SQL injection + breaks on quotes in coupon codes (e.g., "MOTHER'S-DAY")
+
+OPTIONS
+  1. Fix: Parameterize query → db.query('...WHERE code = $1', [couponCode])
+  2. Revert: git revert abc1234f (creates new commit, safe for main)
+  3. Cherry-pick fix onto v3.2.0 patch branch
+```

--- a/.claude/skills/i18n-audit/SKILL.md
+++ b/.claude/skills/i18n-audit/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: i18n-audit
+description: Internationalization completeness audit and key synchronization. Finds missing translation keys, hardcoded strings, pluralization bugs, RTL layout issues, date/number formatting gaps, and untranslated copy. Supports i18next, react-intl, vue-i18n, next-intl, and custom JSON locale files. Use when adding a new language, auditing translation completeness, or debugging locale mismatch errors.
+---
+
+# i18n Audit
+
+Find every missing translation, hardcoded string, and locale gap before your users do.
+
+## Quick Start
+
+```
+/i18n-audit                    — full audit across all locales
+/i18n-audit --lang pt-BR       — audit single locale
+/i18n-audit --missing          — show only missing keys
+/i18n-audit --hardcoded        — scan codebase for hardcoded strings
+/i18n-audit --fix              — add placeholder keys for missing translations
+/i18n-audit --new-lang es      — scaffold a new language from base locale
+```
+
+## What Gets Audited
+
+### Key Completeness
+- Keys present in base locale (`en`) but missing in target locales
+- Keys present in target locales but removed from base (orphaned keys)
+- Nested key depth mismatches
+- Empty string values (untranslated placeholder)
+
+### Code Quality
+- Hardcoded strings in JSX/TSX/Vue templates
+- Missing plural forms (`one` / `other` / `few` / `many` / `zero`)
+- Missing interpolation variables (`{name}` in key but `{user}` in code)
+- Date formatting using `new Date().toLocaleDateString()` without locale param
+
+### Layout Issues
+- Fixed-width containers that break with German/Japanese text expansion
+- Missing `dir="rtl"` for Arabic / Hebrew locales
+- Icons or arrows that assume LTR direction
+
+### Number / Currency / Date
+- Hardcoded `$` currency symbols
+- Hardcoded date formats (`MM/DD/YYYY`)
+- Missing `Intl.NumberFormat` / `Intl.DateTimeFormat` locale params
+
+## Output Format
+
+```
+i18n AUDIT REPORT — 2026-06-14
+================================
+Base locale: en  |  Target locales: pt-BR, es, fr, de, ja
+
+COMPLETENESS
+  pt-BR  96/100  ✅  8 missing keys
+  es     88/100  ⚠️  24 missing keys
+  fr     71/100  ❌  58 missing keys (stale, needs attention)
+  de     100/100 ✅  complete
+  ja     45/100  ❌  110 missing keys
+
+MISSING KEYS (es)
+  checkout.summary.discount_label
+  checkout.summary.free_shipping
+  profile.settings.notification_email
+  ... (21 more)
+
+HARDCODED STRINGS DETECTED
+  src/components/Header.tsx:14  → "Welcome back, "
+  src/pages/checkout.tsx:87    → "Free shipping on orders over $50"
+  src/utils/date.ts:23         → new Date().toLocaleDateString() ← no locale
+
+PLURAL ISSUES
+  pt-BR → cart.items_count: missing 'other' form
+  es    → notification.unread: uses 'plural' (nonstandard), should be 'other'
+
+ORPHANED KEYS (in pt-BR but not in en — likely stale)
+  auth.login_with_facebook  ← Facebook login removed 3 months ago
+  checkout.cod_payment      ← COD feature removed
+```
+
+## Common Fixes
+
+### Add missing plural forms (i18next)
+```json
+{
+  "cart": {
+    "items_count_one": "{{count}} item",
+    "items_count_other": "{{count}} items"
+  }
+}
+```
+
+### Currency with Intl
+```typescript
+// ❌
+`$${price.toFixed(2)}`
+
+// ✅
+new Intl.NumberFormat(locale, {
+  style: 'currency',
+  currency: currencyCode,
+}).format(price)
+```
+
+### Date with locale
+```typescript
+// ❌
+new Date(ts).toLocaleDateString()
+
+// ✅
+new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(new Date(ts))
+```
+
+### RTL support
+```tsx
+// globals.css
+[dir="rtl"] .card-icon { transform: scaleX(-1); }
+
+// layout
+<html lang={locale} dir={rtlLocales.includes(locale) ? 'rtl' : 'ltr'}>
+```
+
+## New Language Scaffold
+
+Running `/i18n-audit --new-lang es` will:
+1. Copy base locale JSON structure
+2. Mark all values as `[NEEDS TRANSLATION] Original: ...`
+3. Add new lang to i18n config
+4. Add new lang to CI translation coverage check

--- a/.claude/skills/incident-runbook/SKILL.md
+++ b/.claude/skills/incident-runbook/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: incident-runbook
+description: Incident response runbooks, on-call workflows, and postmortem templates. Generates severity-tiered runbooks, communication templates, timeline reconstruction, and blameless postmortem docs. Use when user is in an incident, doing on-call prep, writing a postmortem, or building incident response playbooks.
+---
+
+# Incident Runbook
+
+Structured incident response — from first alert to blameless postmortem.
+
+## Quick Start
+
+```
+/incident-runbook new <service>     — create runbook for a service
+/incident-runbook triage            — immediate triage checklist
+/incident-runbook postmortem        — generate postmortem from timeline
+/incident-runbook comms             — draft stakeholder communication
+/incident-runbook playbook <error>  — generate playbook for specific error type
+```
+
+## Severity Matrix
+
+| Sev | Criteria | Response Time | Who |
+|-----|----------|---------------|-----|
+| **P0** | Prod down, data loss, security breach | 5 min | IC + Eng lead + CTO |
+| **P1** | Core feature degraded, >10% users affected | 15 min | IC + On-call |
+| **P2** | Non-critical feature degraded, workaround exists | 1 hour | On-call |
+| **P3** | Minor issue, low user impact | Next business day | Team |
+
+## Immediate Response (First 15 Minutes)
+
+```
+[ ] 1. Acknowledge alert (prevents duplicate paging)
+[ ] 2. Assess severity → declare P0/P1/P2/P3
+[ ] 3. P0/P1: Open incident Slack channel #inc-YYYY-MM-DD-<slug>
+[ ] 4. Assign Incident Commander (IC) — single decision owner
+[ ] 5. Start timeline doc (incident log)
+[ ] 6. Notify stakeholders (template below)
+[ ] 7. Do NOT start fixing until you understand the blast radius
+```
+
+## Stakeholder Communication Templates
+
+### Initial (within 5 min of P0/P1)
+```
+🔴 INCIDENT DECLARED — P[0/1]
+Service: [service name]
+Impact: [what users can't do]
+Status: Investigating
+IC: @[name]
+Channel: #inc-[slug]
+Next update: in 15 min
+```
+
+### Update (every 15–30 min)
+```
+🟡 INCIDENT UPDATE — P[0/1] — [HH:MM]
+Status: [Investigating / Identified / Fixing / Monitoring]
+Impact: [current user impact]
+Root cause hypothesis: [best theory]
+Actions taken: [what you did]
+Next update: in [X] min
+```
+
+### Resolution
+```
+✅ INCIDENT RESOLVED — P[0/1] — [HH:MM]
+Duration: [X hours Y min]
+Impact: [X users affected, Y% of traffic]
+Root cause: [brief]
+Fix applied: [what was done]
+Postmortem: [link] — due [date]
+```
+
+## Triage Checklist
+
+```
+TRIAGE — [service] — [timestamp]
+=====================================
+[ ] Is the service responding? (curl / health endpoint)
+[ ] Is it all users or a subset? (region / customer / feature)
+[ ] When did it start? (check deploy history, cron jobs, traffic spike)
+[ ] What changed recently? (git log, infra changes, dependency updates)
+[ ] Is the database healthy? (query time, connections, replication lag)
+[ ] Is a dependency degraded? (check status pages, upstream errors)
+[ ] Are error rates spiking or flat-lining?
+[ ] Is it a traffic spike or a code regression?
+```
+
+## Runbook Template (per service)
+
+```markdown
+# Runbook: [Service Name]
+
+## Contacts
+- On-call: @[team-pagerduty-rotation]
+- Escalation: @[eng-lead] → @[cto]
+- External: [vendor support link]
+
+## Dashboards
+- [Grafana link]
+- [Datadog link]
+- [Log query link]
+
+## Common Alerts and Fixes
+
+### Alert: High Error Rate (>1%)
+1. Check recent deploys: `git log --since="2 hours ago"`
+2. Check DB: `SELECT * FROM pg_stat_activity WHERE state='active'`
+3. Rollback if code change: `kubectl rollout undo deploy/[service]`
+
+### Alert: High Latency (p99 > 1s)
+1. Check DB slow queries
+2. Check Redis hit rate
+3. Check external API timeouts
+
+### Rollback Procedure
+```bash
+# Kubernetes
+kubectl rollout undo deployment/[service]
+kubectl rollout status deployment/[service]
+
+# Vercel
+vercel rollback [deployment-url]
+
+# Railway / Render
+# Use dashboard instant rollback button
+```
+```
+
+## Blameless Postmortem Template
+
+```markdown
+# Postmortem: [Incident Title]
+**Date:** YYYY-MM-DD  |  **Severity:** P[0/1]  |  **Duration:** Xh Ymin
+**Authors:** @[names]  |  **Review date:** [date + 7 days]
+
+## Summary
+[2–3 sentence description of what happened, impact, and resolution]
+
+## Impact
+- Users affected: ~X (Y% of total)
+- Duration: HH:MM–HH:MM UTC
+- Revenue impact: $X (if applicable)
+
+## Timeline (UTC)
+| Time | Event |
+|------|-------|
+| 14:32 | Alert fired: error rate >5% |
+| 14:35 | On-call acknowledged |
+| 14:41 | Identified bad deploy at 14:20 |
+| 14:45 | Rollback initiated |
+| 14:52 | Error rate normalized |
+| 15:10 | Declared resolved |
+
+## Root Cause
+[Technical root cause. What failed and why.]
+
+## Contributing Factors
+- [Factor 1: e.g., no canary deployment]
+- [Factor 2: e.g., alert threshold too high]
+
+## What Went Well
+- [e.g., fast detection via synthetic monitoring]
+
+## Action Items
+| Action | Owner | Due |
+|--------|-------|-----|
+| Add canary deploy step to CI | @dev | 2026-06-21 |
+| Lower error rate alert to 0.5% | @ops | 2026-06-17 |
+```

--- a/.claude/skills/load-test/SKILL.md
+++ b/.claude/skills/load-test/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: load-test
+description: Load testing setup, execution, and analysis with k6, Artillery, or Locust. Generates test scripts, defines VU ramp-up scenarios, interprets p99 latency and error rate results, and suggests infrastructure fixes. Use when user wants to load test an API, check throughput limits, validate SLO headroom, or diagnose performance under traffic.
+---
+
+# Load Test
+
+Design, run, and analyze load tests. Find your system's breaking point before users do.
+
+## Quick Start
+
+```
+/load-test scaffold           — generate k6 script from OpenAPI spec or cURL examples
+/load-test run <script>       — execute + stream metrics
+/load-test analyze <results>  — interpret results, flag SLO violations
+/load-test soak 30m           — run soak test (low VU, long duration)
+/load-test spike              — spike test (sudden burst, check recovery)
+```
+
+## Test Scenarios
+
+| Scenario | Goal | Duration |
+|----------|------|----------|
+| **Smoke** | Verify script works at 1 VU | 1 min |
+| **Load** | Simulate expected peak traffic | 30 min |
+| **Stress** | Find breaking point | Ramp to failure |
+| **Soak** | Detect memory leaks, slow drift | 2–8 hours |
+| **Spike** | Instant 10× traffic burst | 1 min burst |
+| **Breakpoint** | Binary search for max TPS | Auto |
+
+## Workflow
+
+Claude will:
+1. Infer endpoints from OpenAPI spec / cURL samples / route files
+2. Generate parameterized k6 or Artillery script
+3. Define realistic VU ramp (warm up → peak → cool down)
+4. Add SLO thresholds (p95 < 500ms, error rate < 1%)
+5. Run test (or provide `docker run` command)
+6. Parse JSON results → surface p50/p95/p99/max + error breakdown
+7. Recommend: cache headers, DB indexes, connection pool size, rate limits
+
+## k6 Script Template
+
+```javascript
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+import { Rate } from 'k6/metrics'
+
+const errorRate = new Rate('errors')
+
+export const options = {
+  stages: [
+    { duration: '2m', target: 50 },   // ramp up
+    { duration: '5m', target: 50 },   // sustain peak
+    { duration: '2m', target: 0 },    // ramp down
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<500', 'p(99)<1000'],
+    errors: ['rate<0.01'],
+  },
+}
+
+export default function () {
+  const res = http.get('https://api.example.com/products')
+  check(res, { 'status 200': (r) => r.status === 200 })
+  errorRate.add(res.status !== 200)
+  sleep(1)
+}
+```
+
+## Artillery Script Template
+
+```yaml
+config:
+  target: "https://api.example.com"
+  phases:
+    - duration: 60
+      arrivalRate: 10
+      name: Warm up
+    - duration: 300
+      arrivalRate: 50
+      name: Peak load
+
+scenarios:
+  - name: "Browse products"
+    flow:
+      - get:
+          url: "/products"
+          expect:
+            - statusCode: 200
+            - maxResponseTime: 500
+```
+
+## Results Interpretation
+
+```
+/load-test analyze results.json
+
+LOAD TEST RESULTS — 2026-06-14
+================================
+Duration: 9m  |  VUs peak: 50  |  Total requests: 12,430
+
+LATENCY
+  p50:  42ms   ✅
+  p95:  380ms  ✅ (threshold: <500ms)
+  p99:  1,240ms ❌ (threshold: <1000ms)
+  max:  4,800ms ❌
+
+ERROR RATE: 2.3% ❌ (threshold: <1%)
+  404 Not Found:    0.1%
+  502 Bad Gateway:  1.8%  ← upstream timeout
+  503 Unavailable:  0.4%
+
+BOTTLENECKS IDENTIFIED
+  → DB query P99 800ms on /products?filter=... — add composite index
+  → Upstream timeout at 2.2× peak — increase ALB timeout or add circuit breaker
+  → Memory grows 15MB/min during soak — suspect connection leak in pool
+
+RECOMMENDATIONS
+  1. Add index: CREATE INDEX ON products(category_id, created_at DESC)
+  2. Set keepAlive timeout > ALB idle timeout (current: 60s, ALB: 120s)
+  3. Limit connection pool max to CPUs × 2 (not unlimited)
+```
+
+## SLO Thresholds Reference
+
+| Tier | p95 | p99 | Error Rate |
+|------|-----|-----|-----------|
+| Real-time (chat, trading) | <100ms | <250ms | <0.01% |
+| Interactive (API, web) | <300ms | <800ms | <0.1% |
+| Batch (reports, exports) | <2s | <5s | <1% |

--- a/.claude/skills/openapi-generate/SKILL.md
+++ b/.claude/skills/openapi-generate/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: openapi-generate
+description: Generate OpenAPI 3.1 specs from existing code (routes, controllers, types, Zod/Joi schemas), or generate code from an existing spec. Produces valid openapi.yaml, typed client SDKs, mock servers, and Postman collections. Use when documenting an API, onboarding clients, generating typed SDKs, or migrating to spec-first development.
+---
+
+# OpenAPI Generate
+
+Code → spec → SDK → mocks. Full API documentation lifecycle.
+
+## Quick Start
+
+```
+/openapi-generate                    — generate spec from codebase routes
+/openapi-generate --from spec        — generate code/SDK from openapi.yaml
+/openapi-generate --sdk typescript   — generate TypeScript client SDK
+/openapi-generate --mock             — generate mock server from spec
+/openapi-generate --postman          — export Postman collection
+/openapi-generate --validate         — validate existing openapi.yaml
+```
+
+## Directions
+
+### Code → Spec (most common)
+Claude reads your route files, controllers, and type definitions, then produces a complete `openapi.yaml`.
+
+### Spec → Code (spec-first)
+Claude reads an existing `openapi.yaml` and generates:
+- TypeScript types / Zod schemas
+- Route handlers (Express / Fastify / NestJS / Next.js)
+- Typed client SDK
+- Test fixtures
+
+## Workflow — Code to Spec
+
+Claude will:
+1. Discover route files (Express `router.get`, NestJS `@Get`, Next.js `route.ts`, etc.)
+2. Extract path params, query params, request body, response shapes
+3. Infer types from TypeScript / Zod / Joi / Prisma schema
+4. Generate `openapi.yaml` with examples
+5. Add `$ref` components to avoid duplication
+6. Validate with `@redocly/cli lint`
+
+## Generated Spec Example
+
+```yaml
+openapi: 3.1.0
+info:
+  title: Products API
+  version: 1.0.0
+
+paths:
+  /products:
+    get:
+      summary: List products
+      operationId: listProducts
+      parameters:
+        - name: category
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /products/{id}:
+    get:
+      summary: Get product by ID
+      operationId: getProduct
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Product'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+components:
+  schemas:
+    Product:
+      type: object
+      required: [id, name, price]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        price:
+          type: number
+          format: float
+        category:
+          type: string
+```
+
+## SDK Generation
+
+```bash
+# TypeScript (via openapi-typescript)
+/openapi-generate --sdk typescript
+# → generates: src/types/api.ts (fully typed)
+
+# Typed fetch client (openapi-fetch)
+/openapi-generate --sdk typescript-fetch
+# → generates: src/lib/api-client.ts
+
+# Python (via openapi-python-client)
+/openapi-generate --sdk python
+```
+
+### TypeScript SDK Example
+
+```typescript
+import createClient from 'openapi-fetch'
+import type { paths } from './types/api'
+
+const client = createClient<paths>({ baseUrl: 'https://api.example.com' })
+
+// Fully typed — autocomplete on params + response
+const { data, error } = await client.GET('/products/{id}', {
+  params: { path: { id: '123' } },
+})
+// data.name is typed as string
+```
+
+## Mock Server
+
+```bash
+/openapi-generate --mock
+# Generates: mock-server/ (uses Prism)
+# Run: npx @stoplight/prism-cli mock openapi.yaml
+# → Serves realistic mocks from examples in spec
+```
+
+## Validation
+
+```
+OPENAPI VALIDATION — openapi.yaml
+====================================
+❌ 3 errors | ⚠️ 7 warnings
+
+ERRORS
+  [E1] /paths/~1orders~1{id}/put — requestBody is required but not defined
+  [E2] /components/schemas/User — 'email' format should be 'email' not 'string'
+  [E3] Missing operationId on GET /users
+
+WARNINGS
+  [W1] No examples defined for 5 schemas (reduces mock quality)
+  [W2] Missing 401/403 responses on authenticated endpoints
+```
+
+## Frameworks Supported
+
+| Framework | Route Discovery |
+|-----------|----------------|
+| Express / Fastify | `router.get/post/put/delete` |
+| NestJS | `@Get`, `@Post`, `@Controller` decorators |
+| Next.js App Router | `route.ts` export handlers |
+| FastAPI (Python) | `@app.get`, `@app.post` |
+| Django REST | ViewSet + `urlpatterns` |
+| Hono | `app.get/post` |

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ This repository ships a marketplace manifest (`.claude-plugin/marketplace.json`)
 Inside a Claude Code session, run the slash command:
 
 ```text
-/plugin marketplace add Andersonlimahw/ai-marketplace
+/plugin marketplace add Andersonlimahw/lemon-ai-hub
 ```
 
 You can also point at any Git URL or a local path:
 
 ```text
-/plugin marketplace add https://github.com/Andersonlimahw/ai-marketplace.git
-/plugin marketplace add ./ai-marketplace          # local checkout
+/plugin marketplace add https://github.com/Andersonlimahw/lemon-ai-hub.git
+/plugin marketplace add ./lemon-ai-hub          # local checkout
 ```
 
 ### 2. Browse & install plugins
@@ -31,8 +31,8 @@ Open the interactive installer, or install a plugin by name using the `plugin@ma
 
 ```text
 /plugin                                            # browse the catalog UI
-/plugin install spotify-squad@ai-marketplace
-/plugin install agentic-value-loops@ai-marketplace
+/plugin install spotify-squad@lemon-ai-hub
+/plugin install agentic-value-loops@lemon-ai-hub
 ```
 
 | Plugin | What you get |
@@ -44,8 +44,8 @@ Open the interactive installer, or install a plugin by name using the `plugin@ma
 
 ```text
 /plugin marketplace list                           # show registered marketplaces
-/plugin marketplace update ai-marketplace          # pull the latest manifest
-/plugin marketplace remove ai-marketplace          # unregister
+/plugin marketplace update lemon-ai-hub          # pull the latest manifest
+/plugin marketplace remove lemon-ai-hub          # unregister
 ```
 
 > Plugins bundle their own agents, skills, and commands — once installed they are auto-discovered by Claude Code. The standalone `skills/` in this repo are shared globally via symlinks instead (see **Installation & Symlink Setup** below).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ By utilizing symbolic links, all agents are configured to point back to this rep
 
 ```mermaid
 graph TD
-    Marketplace["/Projects/IA/ai-marketplace/skills/"]
+    Marketplace["/Projects/IA/lemon-ai-hub/skills/"]
     Claude["~/.claude/skills/"]
     Codex["~/.codex/skills/"]
     OpenCode["~/.opencode/skills/"]

--- a/plugins/agentic-value-loops/README.md
+++ b/plugins/agentic-value-loops/README.md
@@ -17,7 +17,7 @@ Este plugin transforma automações documentadas em **Value Loops** executáveis
 ## 🚀 Instalação
 
 ```bash
-# Na raiz do seu repositório ai-marketplace:
+# Na raiz do seu repositório lemon-ai-hub:
 ./plugins/agentic-value-loops/scripts/install.sh
 ```
 

--- a/plugins/agentic-value-loops/plugin.json
+++ b/plugins/agentic-value-loops/plugin.json
@@ -6,7 +6,7 @@
     "name": "Anderson Lima",
     "url": "https://andersonlimahw.github.io"
   },
-  "repository": "https://github.com/Andersonlimahw/ai-marketplace",
+  "repository": "https://github.com/Andersonlimahw/lemon-ai-hub",
   "license": "MIT",
   "keywords": [
     "loops",

--- a/plugins/spotify-squad/README.md
+++ b/plugins/spotify-squad/README.md
@@ -16,7 +16,7 @@ A squad é composta por 12 agentes especialistas, liderados por um orquestrador 
 ## 🚀 Instalação
 
 ```bash
-# Na raiz do seu repositório ai-marketplace:
+# Na raiz do seu repositório lemon-ai-hub:
 ./plugins/spotify-squad/scripts/install.sh
 ```
 

--- a/plugins/spotify-squad/plugin.json
+++ b/plugins/spotify-squad/plugin.json
@@ -6,7 +6,7 @@
     "name": "Anderson Lima",
     "url": "https://andersonlimahw.github.io"
   },
-  "repository": "https://github.com/Andersonlimahw/ai-marketplace",
+  "repository": "https://github.com/Andersonlimahw/lemon-ai-hub",
   "license": "MIT",
   "keywords": [
     "squad",

--- a/scripts/marketplace
+++ b/scripts/marketplace
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# marketplace - Command-line interface to manage plugins and skills in ai-marketplace
+# marketplace - Command-line interface to manage plugins and skills in lemon-ai-hub
 
 set -euo pipefail
 
@@ -11,7 +11,7 @@ CYAN='\033[0;36m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
-REPO_DIR="/Users/andersonlimadev/Projects/IA/ai-marketplace"
+REPO_DIR="/Users/andersonlimadev/Projects/IA/lemon-ai-hub"
 SKILLS_DIR="$REPO_DIR/skills"
 PLUGINS_DIR="$REPO_DIR/plugins"
 

--- a/scripts/setup-symlinks.sh
+++ b/scripts/setup-symlinks.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-REPO_SKILLS_DIR="/Users/andersonlimadev/Projects/IA/ai-marketplace/skills"
+REPO_SKILLS_DIR="/Users/andersonlimadev/Projects/IA/lemon-ai-hub/skills"
 
 setup_symlink() {
   local target="$1"


### PR DESCRIPTION
## Summary
Este PR introduz um novo conjunto de **Skills** e **Plugins** especializados em CI/CD e governança de código, além de oficializar o rename do repositório de `ai-marketplace` para `lemon-ai-hub`.

## Changes

### 🚀 Novas Skills (.claude/skills)
Adicionadas 13 novas skills fundamentais para automação e qualidade:
- **feature-purge**: Remoção segura de features completas e código órfão.
- **git-bisect-ai**: Debug assistido por AI usando git bisect para localizar bugs.
- **incident-runbook**: Scripts e processos para resposta a incidentes.
- **chaos-test**: Framework para execução de testes de resiliência.
- **async-patterns**: Otimização e correção de padrões assíncronos.
- **openapi-generate**: Geração automatizada de specs e contratos.
- **load-test**: Estratégias de teste de carga e performance.
- **db-index-advisor**: Consultoria em performance de banco de dados.
- **a11y-audit**: Auditoria automatizada de acessibilidade.
- **bundle-analyzer**: Controle e análise de tamanho de bundle.
- **code-smell**: Detecção precoce de dívida técnica.
- **feature-flag**: Gestão de lifecycle de flags.
- **i18n-audit**: Sincronização e auditoria de traduções.

### 🧩 Novos Plugins (.claude/plugins)
12 novos plugins prontos para integração no CLI:
- `a11y-guardian`, `async-advisor`, `bundle-watch`, `chaos-runner`, `code-smell-detector`, `commit-quality`, `db-advisor`, `feature-flags`, `i18n-sync`, `incident-center`, `load-test-runner`, `openapi-hub`.

### 🔧 Infra & Branding
- Rename oficial do repositório para `lemon-ai-hub` em todos os manifestos, READMEs e scripts.
- Atualização do `marketplace.json` para refletir os novos metadados.

## Testing
- [x] Verificado o carregamento das novas skills via `activate_skill`.
- [x] Validada a estrutura dos `plugin.json` nos novos diretórios.
- [x] Scripts de instalação (`setup-symlinks.sh`) testados com o novo path.

## Impact
- Expansão significativa das capacidades de auditoria e automação do CLI.
- Necessário atualizar referências locais de quem já clonou o repo devido ao rename.
