### PR TITLE
fix(hub): register cli plugins in marketplace + add sync rule

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -147,6 +147,38 @@
       ]
     },
     {
+      "name": "cli-generator",
+      "source": "./plugins/cli-generator",
+      "description": "Generate a complete, production-ready CLI in Bun from a SPEC, OpenAPI contract, JSON Schema, or natural-language description. Outputs a runnable binary with commander-style arg parsing, autocomplete, man page, and token-aware output formatting.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "cli-generator",
+        "cli",
+        "bun",
+        "code-generation",
+        "commander"
+      ]
+    },
+    {
+      "name": "cli-wrapper",
+      "source": "./plugins/cli-wrapper",
+      "description": "Wrapper that bridges the AI harness to external CLIs — captures help output, documents commands, saves input/output token metrics, and provides a standardized interface so the harness invokes CLIs without context bloat.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "cli-wrapper",
+        "cli",
+        "wrapper",
+        "token-saving",
+        "command-line"
+      ]
+    },
+    {
       "name": "code-review-adversary",
       "source": "./plugins/code-review-adversary",
       "description": ">",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,15 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## Project Rules
+
+Mandatory project rules live in `docs/rules/`. Read and apply them before touching
+the affected areas:
+
+- [`docs/rules/marketplace-sync.md`](docs/rules/marketplace-sync.md) — every plugin
+  in `plugins/` MUST be registered in `.claude-plugin/marketplace.json` in the same
+  change. Never add/rename/remove a plugin without syncing the marketplace.
+
 ## graphify
 
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.

--- a/docs/rules/marketplace-sync.md
+++ b/docs/rules/marketplace-sync.md
@@ -1,0 +1,50 @@
+---
+title: Plugin ↔ Marketplace Sync (MANDATORY)
+status: active
+updated: 2026-06-15
+related: [docs/cli-marketplace.md, docs/architecture.md, AGENTS.md]
+---
+
+# Rule: Every plugin MUST be registered in `marketplace.json`
+
+**Why:** PR #8 added the `cli-generator` and `cli-wrapper` plugins under `plugins/`
+but did **not** update `.claude-plugin/marketplace.json`. The plugins existed on
+disk yet were invisible to the marketplace — they could not be discovered or
+installed. This rule exists so that mismatch never happens again.
+
+## The invariant
+
+The set of directories in `plugins/` MUST equal the set of entries in
+`.claude-plugin/marketplace.json` → `plugins[]`. No orphans on either side.
+
+```
+count(plugins/*/)  ==  count(marketplace.json .plugins[])
+```
+
+## When you add, rename, or remove a plugin
+
+Whenever you touch `plugins/` you MUST, in the **same** change/PR:
+
+1. **Add** — create the plugin dir AND append a matching `plugins[]` entry in
+   `.claude-plugin/marketplace.json` (alphabetical order by `name`). Copy
+   `name`, `description`, `version`, `license`, and `keywords` from the
+   plugin's own `plugin.json` so they stay consistent.
+2. **Rename** — update both the directory name and the `name` + `source` fields.
+3. **Remove** — delete the dir AND its `plugins[]` entry.
+
+## How to verify before committing
+
+```bash
+# Plugin dirs missing from the marketplace (must print nothing):
+comm -23 \
+  <(ls -1 plugins/ | sort) \
+  <(grep -oE '"\./plugins/[^"]+"' .claude-plugin/marketplace.json \
+      | sed -E 's#.*/plugins/([^"]+)"#\1#' | sort)
+
+# Counts must match:
+echo "dirs:     $(ls -1d plugins/*/ | wc -l)"
+echo "registry: $(grep -c '"source": "./plugins/' .claude-plugin/marketplace.json)"
+```
+
+If `comm` prints any name, that plugin is unregistered — fix `marketplace.json`
+before merging.


### PR DESCRIPTION
## Problema

[PR #8](https://github.com/Andersonlimahw/lemon-ai-hub/pull/8) adicionou os plugins `cli-generator` e `cli-wrapper` em `plugins/`, mas **não** atualizou `.claude-plugin/marketplace.json`. Resultado: 37 diretórios de plugin, apenas 35 registrados — os 2 ficaram indescobríveis/não instaláveis.

## Mudanças

- **Registra** `cli-generator` e `cli-wrapper` em `marketplace.json` (em ordem alfabética, metadados copiados do `plugin.json` de cada um). Agora `37 dirs == 37 entries`.
- **Nova regra** `docs/rules/marketplace-sync.md`: todo plugin em `plugins/` DEVE ser registrado no `marketplace.json` na mesma mudança. Inclui snippet de verificação (`comm` + contagem).
- **AGENTS.md**: nova seção "Project Rules" referenciando a regra.

## Verificação

```
unregistered (comm -23): <vazio>
dirs:     37
registry: 37
json:     OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)