### PR TITLE
feat(ai): add workspace orchestrator plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,7 +60,7 @@
     {
       "name": "ai-workspace-orchestrator",
       "source": "./plugins/ai-workspace-orchestrator",
-      "description": "Project and workspace AI setup orchestrator. Builds AGENTS.md/CLAUDE.md contracts, optional global or project skills, and Spotify Squad-style agent/subagent topology for single apps, monorepos, and multi-domain workspaces.",
+      "description": "Project and workspace AI setup orchestrator. Builds AGENTS.md/CLAUDE.md contracts, optional global or project skills, Spotify Squad-style agent/subagent topology, and adversarial setup review for single apps, monorepos, and multi-domain workspaces.",
       "version": "1.0.0",
       "license": "MIT",
       "keywords": [
@@ -70,6 +70,7 @@
         "subagents",
         "skills",
         "orchestration",
+        "adversarial-review",
         "spotify-squad",
         "monorepo",
         "codex",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -58,6 +58,25 @@
       ]
     },
     {
+      "name": "ai-workspace-orchestrator",
+      "source": "./plugins/ai-workspace-orchestrator",
+      "description": "Project and workspace AI setup orchestrator. Builds AGENTS.md/CLAUDE.md contracts, optional global or project skills, and Spotify Squad-style agent/subagent topology for single apps, monorepos, and multi-domain workspaces.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "ai-native",
+        "workspace-setup",
+        "agents",
+        "subagents",
+        "skills",
+        "orchestration",
+        "spotify-squad",
+        "monorepo",
+        "codex",
+        "claude"
+      ]
+    },
+    {
       "name": "async-advisor",
       "source": "./plugins/async-advisor",
       "description": "Async and concurrency static analysis plugin. Scans TypeScript/JavaScript codebases for race conditions, unbounded Promise.all, missing AbortController, swallowed rejections, and N+1 async patterns. Runs as a pre-commit hook or CI check and provides inline fix suggestions.",

--- a/plugins/ai-workspace-orchestrator/.codex-plugin/plugin.json
+++ b/plugins/ai-workspace-orchestrator/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "ai-workspace-orchestrator",
+  "version": "1.0.0",
+  "description": "Project and workspace AI setup orchestrator. Builds AGENTS.md/CLAUDE.md contracts, optional global or project skills, and Spotify Squad-style agent/subagent topology for single apps, monorepos, and multi-domain workspaces.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "repository": "https://github.com/Andersonlimahw/lemon-ai-hub",
+  "license": "MIT",
+  "keywords": [
+    "ai-native",
+    "workspace-setup",
+    "agents",
+    "subagents",
+    "skills",
+    "orchestration",
+    "spotify-squad",
+    "monorepo",
+    "codex",
+    "claude"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "AI Workspace Orchestrator",
+    "shortDescription": "Configure AI agents, skills, and workspace contracts.",
+    "longDescription": "Guided setup for project or domain AI operating systems. It asks the minimum necessary questions, discovers repo topology, creates AGENTS.md and CLAUDE.md contracts, and plans or installs global/project skills and Spotify Squad-style orchestrators.",
+    "developerName": "Anderson Lima",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write",
+      "Orchestration"
+    ],
+    "defaultPrompt": [
+      "Set up AI config for this workspace.",
+      "Create a project agent orchestrator.",
+      "Design local skills for this domain."
+    ]
+  }
+}

--- a/plugins/ai-workspace-orchestrator/.codex-plugin/plugin.json
+++ b/plugins/ai-workspace-orchestrator/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-workspace-orchestrator",
   "version": "1.0.0",
-  "description": "Project and workspace AI setup orchestrator. Builds AGENTS.md/CLAUDE.md contracts, optional global or project skills, and Spotify Squad-style agent/subagent topology for single apps, monorepos, and multi-domain workspaces.",
+  "description": "Project and workspace AI setup orchestrator. Builds AGENTS.md/CLAUDE.md contracts, optional global or project skills, Spotify Squad-style agent/subagent topology, and adversarial setup review for single apps, monorepos, and multi-domain workspaces.",
   "author": {
     "name": "Anderson Lima",
     "url": "https://andersonlimahw.github.io"
@@ -15,6 +15,7 @@
     "subagents",
     "skills",
     "orchestration",
+    "adversarial-review",
     "spotify-squad",
     "monorepo",
     "codex",
@@ -24,7 +25,7 @@
   "interface": {
     "displayName": "AI Workspace Orchestrator",
     "shortDescription": "Configure AI agents, skills, and workspace contracts.",
-    "longDescription": "Guided setup for project or domain AI operating systems. It asks the minimum necessary questions, discovers repo topology, creates AGENTS.md and CLAUDE.md contracts, and plans or installs global/project skills and Spotify Squad-style orchestrators.",
+    "longDescription": "Guided setup for project or domain AI operating systems. It asks the minimum necessary questions, discovers repo topology, creates AGENTS.md and CLAUDE.md contracts, plans or installs global/project skills, designs Spotify Squad-style orchestrators, and reviews durable setup changes adversarially before merge.",
     "developerName": "Anderson Lima",
     "category": "Productivity",
     "capabilities": [
@@ -35,7 +36,7 @@
     "defaultPrompt": [
       "Set up AI config for this workspace.",
       "Create a project agent orchestrator.",
-      "Design local skills for this domain."
+      "Adversarially review this AI setup."
     ]
   }
 }

--- a/plugins/ai-workspace-orchestrator/AGENTS.md
+++ b/plugins/ai-workspace-orchestrator/AGENTS.md
@@ -1,0 +1,42 @@
+# AI Workspace Orchestrator
+
+Use this plugin to create the AI operating layer for a project, workspace, or domain.
+
+## Core Flow
+
+```mermaid
+flowchart TD
+    A[User setup request] --> B[Setup AI Workspace]
+    B --> C{Depth}
+    C -->|low| D[Minimal AGENTS and CLAUDE contract]
+    C -->|medium| E[Project skills and verification gates]
+    C -->|high| F[Agents, subagents, squad map]
+    C -->|max| G[Domain orchestrator, cross-repo map, handoff loop]
+    E --> H[Workspace Contract]
+    F --> H
+    G --> H
+    H --> I[Context Handoff]
+```
+
+## Skills
+
+| Skill | Purpose |
+| --- | --- |
+| `setup-ai-workspace` | Run the question-driven setup wizard and produce the setup profile. |
+| `write-project-skill` | Create global or project-local skills with progressive disclosure. |
+| `build-agent-orchestrator` | Create a Spotify Squad-style orchestrator and only the needed subagents. |
+| `workspace-contract` | Write or update AGENTS.md and CLAUDE.md, including symlink strategy. |
+| `context-handoff` | Save a compact handoff for another agent or future session. |
+
+## Agent
+
+Use `workspace-orchestrator` for multi-domain setup work. It inspects the current repo before asking and asks one question at a time when a decision cannot be inferred.
+
+## Operating Rules
+
+- Prefer current repo evidence over user guesses when topology can be discovered.
+- Ask one decision at a time, with a recommended answer.
+- Create only skills and agents tied to present domains.
+- For monorepos or multi-repo domains, create one root orchestrator and specialist agents per real boundary.
+- Keep `AGENTS.md` canonical. Use a `CLAUDE.md` symlink to `AGENTS.md` when supported; otherwise create a short pointer file.
+- Preserve existing project instructions and append a clearly delimited AI workspace block.

--- a/plugins/ai-workspace-orchestrator/AGENTS.md
+++ b/plugins/ai-workspace-orchestrator/AGENTS.md
@@ -12,7 +12,8 @@ flowchart TD
     C -->|medium| E[Project skills and verification gates]
     C -->|high| F[Agents, subagents, squad map]
     C -->|max| G[Domain orchestrator, cross-repo map, handoff loop]
-    E --> H[Workspace Contract]
+    D --> H[Workspace Contract]
+    E --> H
     F --> H
     G --> H
     H --> I[Adversarial Review]

--- a/plugins/ai-workspace-orchestrator/AGENTS.md
+++ b/plugins/ai-workspace-orchestrator/AGENTS.md
@@ -15,7 +15,8 @@ flowchart TD
     E --> H[Workspace Contract]
     F --> H
     G --> H
-    H --> I[Context Handoff]
+    H --> I[Adversarial Review]
+    I --> J[Context Handoff]
 ```
 
 ## Skills
@@ -26,6 +27,7 @@ flowchart TD
 | `write-project-skill` | Create global or project-local skills with progressive disclosure. |
 | `build-agent-orchestrator` | Create a Spotify Squad-style orchestrator and only the needed subagents. |
 | `workspace-contract` | Write or update AGENTS.md and CLAUDE.md, including symlink strategy. |
+| `adversarial-setup-review` | Review setup changes as a principal engineer before merge. |
 | `context-handoff` | Save a compact handoff for another agent or future session. |
 
 ## Agent
@@ -40,3 +42,4 @@ Use `workspace-orchestrator` for multi-domain setup work. It inspects the curren
 - For monorepos or multi-repo domains, create one root orchestrator and specialist agents per real boundary.
 - Keep `AGENTS.md` canonical. Use a `CLAUDE.md` symlink to `AGENTS.md` when supported; otherwise create a short pointer file.
 - Preserve existing project instructions and append a clearly delimited AI workspace block.
+- Run adversarial setup review before merging durable workspace instructions.

--- a/plugins/ai-workspace-orchestrator/agents/workspace-orchestrator.md
+++ b/plugins/ai-workspace-orchestrator/agents/workspace-orchestrator.md
@@ -33,6 +33,7 @@ Core responsibilities:
 3. Decide which skills belong globally and which belong inside the project.
 4. Decide whether to reuse Spotify Squad agents or create smaller local agents.
 5. Produce or update AGENTS.md and CLAUDE.md without erasing existing instructions.
+6. Do not mutate files until the user asks to apply the setup.
 
 Process:
 1. Inspect current root, existing AGENTS.md/CLAUDE.md, workspace manifests, apps, packages, and plugin folders.

--- a/plugins/ai-workspace-orchestrator/agents/workspace-orchestrator.md
+++ b/plugins/ai-workspace-orchestrator/agents/workspace-orchestrator.md
@@ -1,0 +1,65 @@
+---
+name: workspace-orchestrator
+description: Use this agent when configuring AI operating instructions, local skills, agent/subagent topology, or cross-project orchestration for a repo, monorepo, workspace, or product domain. Examples:
+
+<example>
+Context: A user wants AI setup for a monorepo with backend and frontend apps.
+user: "Set up the agents and AGENTS.md for this workspace"
+assistant: "I'll inspect the repo topology, identify domains, then create a root orchestrator with only the needed specialist agents and workspace instructions."
+<commentary>
+The request needs cross-domain workspace orchestration and project instruction files.
+</commentary>
+</example>
+
+<example>
+Context: A user wants to decide whether to create global or project skills.
+user: "Should these skills be global or just for this project?"
+assistant: "I'll classify reusable vs project-specific knowledge and recommend scope before creating any skill."
+<commentary>
+The request is about skill scoping and AI setup decisions.
+</commentary>
+</example>
+
+model: inherit
+color: cyan
+tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash"]
+---
+
+You are a workspace AI setup architect. You design the smallest effective AI operating layer for a project, workspace, monorepo, or product domain.
+
+Core responsibilities:
+1. Discover repo topology before asking questions that files can answer.
+2. Choose setup depth: low, medium, high, or max.
+3. Decide which skills belong globally and which belong inside the project.
+4. Decide whether to reuse Spotify Squad agents or create smaller local agents.
+5. Produce or update AGENTS.md and CLAUDE.md without erasing existing instructions.
+
+Process:
+1. Inspect current root, existing AGENTS.md/CLAUDE.md, workspace manifests, apps, packages, and plugin folders.
+2. If a decision is still unclear, ask one question at a time and include your recommended answer.
+3. Map domains: backend, frontend, mobile, data, infra, design, product, docs, security.
+4. Select the minimum agent topology. Use one orchestrator plus specialist agents only for domains that exist.
+5. Select the minimum skill set. Use project skills for local conventions; use global skills only for reusable workflows.
+6. Write a concise setup profile, then apply it only when the user asked for implementation.
+7. Verify created files, marketplace registration when this repo is involved, and instruction links.
+
+Depth policy:
+- low: one root instruction contract, no new agents unless requested.
+- medium: add focused project skills and verification gates.
+- high: add orchestrator and specialist agents for real domains.
+- max: add cross-repo/domain orchestration, handoff protocol, review loops, and periodic refinement gates.
+
+Quality standards:
+- Do not create agents for absent domains.
+- Do not duplicate long rules across AGENTS.md and CLAUDE.md.
+- Preserve user instructions.
+- Prefer symlink from CLAUDE.md to AGENTS.md when supported; use a pointer file when symlink is unsafe.
+- Keep outputs short enough for future agents to load.
+
+Output format:
+1. Setup profile.
+2. Proposed files.
+3. Agent map.
+4. Skill map.
+5. Verification commands.
+6. Open questions, if any.

--- a/plugins/ai-workspace-orchestrator/plugin.json
+++ b/plugins/ai-workspace-orchestrator/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "ai-workspace-orchestrator",
+  "version": "1.0.0",
+  "description": "Project and workspace AI setup orchestrator. Builds AGENTS.md/CLAUDE.md contracts, optional global or project skills, and Spotify Squad-style agent/subagent topology for single apps, monorepos, and multi-domain workspaces.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "repository": "https://github.com/Andersonlimahw/lemon-ai-hub",
+  "license": "MIT",
+  "keywords": [
+    "ai-native",
+    "workspace-setup",
+    "agents",
+    "subagents",
+    "skills",
+    "orchestration",
+    "spotify-squad",
+    "monorepo",
+    "codex",
+    "claude"
+  ]
+}

--- a/plugins/ai-workspace-orchestrator/plugin.json
+++ b/plugins/ai-workspace-orchestrator/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-workspace-orchestrator",
   "version": "1.0.0",
-  "description": "Project and workspace AI setup orchestrator. Builds AGENTS.md/CLAUDE.md contracts, optional global or project skills, and Spotify Squad-style agent/subagent topology for single apps, monorepos, and multi-domain workspaces.",
+  "description": "Project and workspace AI setup orchestrator. Builds AGENTS.md/CLAUDE.md contracts, optional global or project skills, Spotify Squad-style agent/subagent topology, and adversarial setup review for single apps, monorepos, and multi-domain workspaces.",
   "author": {
     "name": "Anderson Lima",
     "url": "https://andersonlimahw.github.io"
@@ -15,6 +15,7 @@
     "subagents",
     "skills",
     "orchestration",
+    "adversarial-review",
     "spotify-squad",
     "monorepo",
     "codex",

--- a/plugins/ai-workspace-orchestrator/skills/adversarial-setup-review/SKILL.md
+++ b/plugins/ai-workspace-orchestrator/skills/adversarial-setup-review/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: adversarial-setup-review
+description: Principal-engineer adversarial review for AI workspace setup changes, agent/skill topology, AGENTS.md/CLAUDE.md contracts, and plugin marketplace registration. Use when reviewing a PR, diff, or setup plan for overengineering, missing verification, broken orchestration, stale instructions, or weak agent boundaries.
+---
+
+# Adversarial Setup Review
+
+Goal: block fragile AI workspace setups before they become permanent project instructions.
+
+## Review Process
+
+1. Establish scope:
+   - PR, branch diff, staged diff, or proposed setup plan.
+   - Base branch and target project/domain.
+   - Whether files are executable config, docs-only instructions, plugin manifests, skills, or agents.
+2. Load evidence:
+   - `AGENTS.md`, `CLAUDE.md`, plugin manifests, marketplace file, changed skill files, changed agent files, and validation output.
+   - If a claim is not backed by a file or command, treat it as unproven.
+3. Review as a principal engineer:
+   - Assume the author is junior and the setup may be plausible but incomplete.
+   - Challenge every new skill, agent, and rule for necessity, trigger clarity, and verification.
+   - Prefer fewer stronger artifacts over broad vague orchestration.
+4. Report findings first:
+   - Critical issues.
+   - Non-blocking suggestions.
+   - Nitpicks only when they prevent future confusion.
+5. End with a merge verdict.
+
+## Failure Modes To Hunt
+
+- Marketplace drift: plugin directory added, renamed, or removed without matching marketplace entry.
+- Manifest drift: marketplace metadata no longer matches `plugin.json` after changing description, version, license, or keywords.
+- Hollow orchestration: agent names exist, but delegation inputs, outputs, and verification gates are undefined.
+- Overbroad agents: generic specialists created without a real project boundary.
+- Duplicated contracts: long rules copied into both `AGENTS.md` and `CLAUDE.md` instead of one canonical source.
+- Unsafe symlink plan: recommends `CLAUDE.md -> AGENTS.md` without preserving existing content or fallback pointer.
+- Weak skill trigger: description does not say when the skill should load.
+- Bloated skill: body teaches obvious model knowledge instead of local procedure.
+- Missing validation: no `quick_validate.py`, plugin validation, JSON parse, marketplace invariant, or line-level evidence.
+- Unowned cross-domain flow: backend/frontend/mobile/data integration lacks one responsible orchestrator.
+
+## Output Format
+
+```md
+## Adversarial Review
+
+### Critical Issues
+**[Category]** `path:line`
+> Problem.
+> Why this can fail.
+> Required fix.
+
+### Suggestions
+**[Category]** `path:line`
+> Improvement.
+> Why it matters.
+> Suggested direction.
+
+### Residual Risk
+- Risk that remains after the current diff.
+
+### Verdict
+CHANGES REQUESTED | APPROVE WITH COMMENTS | LGTM
+```
+
+## Rules
+
+- Cite exact file lines for every finding.
+- Do not invent failures; if evidence is weak, state the missing evidence.
+- Treat docs-only changes as production behavior when future agents will obey them.
+- Separate must-fix correctness issues from taste.
+- If no blocking issue exists, say so directly and list residual risk.
+- Never praise vague scope. Require a clear owner, trigger, and verification path.

--- a/plugins/ai-workspace-orchestrator/skills/build-agent-orchestrator/SKILL.md
+++ b/plugins/ai-workspace-orchestrator/skills/build-agent-orchestrator/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: build-agent-orchestrator
+description: Design and create a project, workspace, or domain agent orchestrator with optional Spotify Squad-style subagents. Use when the user wants agents, subagents, a squad orchestrator, cross-repo coordination, or backend/frontend/mobile domain delegation.
+---
+
+# Build Agent Orchestrator
+
+Goal: create a minimal manager-worker agent topology that matches the real project shape.
+
+## Process
+
+1. Inspect topology:
+   - Single app, monorepo/workspace, multi-repo domain, or mixed.
+   - Present domains: backend, frontend, mobile, data, infra, QA, security, product, design.
+   - Existing `plugins/spotify-squad`, `agents/`, `.claude/agents`, or project agent folders.
+2. Recommend agent scope:
+   - Project-local for repo-specific orchestration.
+   - Global only for reusable specialist agents.
+   - Hybrid when a global specialist needs project routing rules.
+3. Choose topology:
+   - Single project: one orchestrator, optional specialists.
+   - Monorepo: one root orchestrator, one specialist per app/domain boundary.
+   - Multi-repo domain: one domain orchestrator plus per-repo contracts pointing back to it.
+4. Reuse `spotify-squad` when it fits. Create smaller local agents when the full squad would be overkill.
+5. Write agent files only for real boundaries.
+6. Update `AGENTS.md`/`CLAUDE.md` routing rules.
+7. Verify frontmatter, names, and examples.
+
+## Orchestrator Contract
+
+The orchestrator must define:
+
+- Domain map.
+- Delegation rules.
+- Parallel workstream policy.
+- Inputs each subagent receives.
+- Output format each subagent returns.
+- Integration and verification gate.
+- Escalation path when domains conflict.
+
+## Recommended Agent Set
+
+- Backend present: `backend-engineer`.
+- Frontend present: `frontend-engineer`.
+- Mobile present: `mobile-engineer`.
+- Data present: `data-engineer`.
+- Infrastructure present: `devops-engineer`.
+- Security-sensitive domain: `security-engineer`.
+- Product/design ambiguity: `product-manager`, `ux-researcher`, or `ui-designer`.
+- Cross-domain work: `workspace-orchestrator`.
+
+## Rules
+
+- Ask one question at a time if topology cannot be inferred.
+- Do not create all Spotify Squad agents by default.
+- Prefer `model: inherit` unless the agent has a clear reason to override.
+- Include 2-4 trigger examples in each agent description.
+- Keep tools least-privilege when the target harness supports tool restrictions.
+- Treat agents as autonomous workers; use skills for reusable knowledge.

--- a/plugins/ai-workspace-orchestrator/skills/context-handoff/SKILL.md
+++ b/plugins/ai-workspace-orchestrator/skills/context-handoff/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: context-handoff
+description: Write compact handoff documents for AI workspace setup and agent orchestration work. Use when a session needs to transfer current decisions, suggested skills, open questions, and next actions to another agent or future session.
+---
+
+# Context Handoff
+
+Goal: let a fresh agent continue without rereading the whole conversation.
+
+## Process
+
+1. Save to the OS temp directory by default, not the current workspace.
+2. If the user requests a project artifact, save under the documented project handoff path.
+3. Reference existing PRDs, plans, diffs, commits, and docs by path or URL instead of duplicating them.
+4. Redact secrets, tokens, passwords, private keys, and personal data.
+5. Include suggested skills and agents for the next session.
+
+## Handoff Format
+
+```md
+# Handoff: <topic>
+
+## Current Goal
+<one paragraph>
+
+## Decisions
+- <decision>
+
+## Files And Evidence
+- <path or URL>: <why it matters>
+
+## Suggested Skills
+- <skill>: <when to invoke>
+
+## Suggested Agents
+- <agent>: <workstream>
+
+## Next Actions
+1. <action>
+
+## Open Questions
+- <question, if any>
+```
+
+## Rules
+
+- Keep it compact.
+- Do not duplicate content already stored in authoritative artifacts.
+- Prefer paths and URLs over pasted content.
+- Include enough verification state for a fresh agent to trust what is done.

--- a/plugins/ai-workspace-orchestrator/skills/context-handoff/SKILL.md
+++ b/plugins/ai-workspace-orchestrator/skills/context-handoff/SKILL.md
@@ -9,7 +9,7 @@ Goal: let a fresh agent continue without rereading the whole conversation.
 
 ## Process
 
-1. Save to the OS temp directory by default, not the current workspace.
+1. Save to the OS temp directory by default, not the current workspace. Use the platform temp resolver when available, or `$TMPDIR`/`/tmp` on Unix-like systems, and report the final absolute path.
 2. If the user requests a project artifact, save under the documented project handoff path.
 3. Reference existing PRDs, plans, diffs, commits, and docs by path or URL instead of duplicating them.
 4. Redact secrets, tokens, passwords, private keys, and personal data.

--- a/plugins/ai-workspace-orchestrator/skills/setup-ai-workspace/SKILL.md
+++ b/plugins/ai-workspace-orchestrator/skills/setup-ai-workspace/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: setup-ai-workspace
+description: Interactive AI workspace setup wizard for projects, monorepos, workspaces, and product domains. Use when the user wants to configure AGENTS.md/CLAUDE.md, choose low/medium/high/max setup depth, create global or project skills, or design agent/subagent orchestration.
+---
+
+# Setup AI Workspace
+
+Goal: create the smallest useful AI operating layer for the current project or domain.
+
+## Process
+
+1. Inspect first:
+   - Existing `AGENTS.md`, `CLAUDE.md`, `.codex/`, `.claude/`, `plugins/`, workspace manifests, app folders, package boundaries, and docs.
+   - If the answer is in the codebase, use it instead of asking.
+2. Ask one question at a time only when the decision cannot be inferred.
+3. For every question, include a recommended answer and one-sentence reason.
+4. Produce a setup profile before writing files.
+5. If the user asked to apply the setup, write files surgically and verify them.
+
+## Required Questions
+
+Ask in this order unless already answered:
+
+1. Depth: `low`, `medium`, `high`, or `max`.
+2. Scope: current project, global user setup, or both.
+3. Topology: single project, monorepo/workspace, multi-repo domain, or unknown.
+4. Domains present: backend, frontend, mobile, data, infra, design, product, docs, security.
+5. Skills: none, project-local, global, or both.
+6. Agents: none, project-local, global, reuse `spotify-squad`, or hybrid.
+7. Contract files: canonical `AGENTS.md`, `CLAUDE.md` symlink, pointer file, or preserve existing split.
+8. Handoff: no handoff, temp handoff, or project handoff artifact.
+
+## Depth Matrix
+
+- `low`: root `AGENTS.md`/`CLAUDE.md`, setup profile, basic verification.
+- `medium`: low plus project skills, routing rules, quality gates.
+- `high`: medium plus orchestrator agent, domain subagents, skill map.
+- `max`: high plus cross-repo/domain map, handoff loop, review loop, refinement cadence.
+
+## Output Contract
+
+Return:
+
+1. `Setup Profile`: depth, scope, topology, domains.
+2. `Artifacts`: files to create/update, with global vs project placement.
+3. `Skill Plan`: skill names, triggers, scope, why each exists.
+4. `Agent Plan`: orchestrator, subagents, delegation model.
+5. `Contract Plan`: AGENTS/CLAUDE strategy and symlink/pointer decision.
+6. `Verification`: exact checks to prove setup is complete.
+
+## Rules
+
+- Do not create speculative agents or skills.
+- Prefer project-local skills for repo conventions and global skills for reusable workflows.
+- For monorepos, create one root orchestrator that delegates to app/domain agents.
+- For separate backend/frontend/mobile repos in one domain, create one domain orchestrator and link each repo contract back to it.
+- Preserve existing instructions; append a delimited block instead of rewriting unrelated content.
+- If a symlink is requested but unsupported or risky, create a short pointer file and explain the tradeoff.

--- a/plugins/ai-workspace-orchestrator/skills/workspace-contract/SKILL.md
+++ b/plugins/ai-workspace-orchestrator/skills/workspace-contract/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: workspace-contract
+description: Create or update AGENTS.md and CLAUDE.md workspace contracts for AI coding agents. Use when the user wants project instructions, symlink strategy, orchestrator routing, skill maps, or monorepo/domain AI configuration files.
+---
+
+# Workspace Contract
+
+Goal: make the project readable to future agents in one load.
+
+## Process
+
+1. Read existing `AGENTS.md` and `CLAUDE.md` if present.
+2. Decide canonical file:
+   - Prefer `AGENTS.md` as canonical for multi-agent portability.
+   - Use `CLAUDE.md` as a symlink to `AGENTS.md` when supported and requested.
+   - Use a short pointer file when symlink support is unknown or unsafe.
+3. Append or update a delimited AI workspace block. Preserve unrelated instructions.
+4. Include only operational facts future agents need.
+5. Verify links, symlink target, and absence of duplicated long blocks.
+
+## Required Sections
+
+- Project identity and topology.
+- Domains and owning folders.
+- Setup depth and scope.
+- Skills map: name, scope, trigger, location.
+- Agent map: orchestrator, subagents, delegation rules.
+- Verification commands.
+- Marketplace/plugin sync rules when the repo has `plugins/`.
+- Handoff path and continuation protocol.
+
+## Symlink Policy
+
+Use this decision order:
+
+1. If both files already contain meaningful content, preserve both and add cross-links.
+2. If `AGENTS.md` is canonical and `CLAUDE.md` is absent, create `CLAUDE.md -> AGENTS.md` when the filesystem and user allow symlinks.
+3. If symlink is unsafe, create a short `CLAUDE.md` pointer that references `AGENTS.md`.
+4. Never replace user-authored instructions without preserving them.
+
+## Minimal Block
+
+```md
+## AI Workspace
+
+Depth: medium
+Topology: monorepo
+Canonical instructions: AGENTS.md
+
+Skills:
+- setup-ai-workspace: project setup and routing
+
+Agents:
+- workspace-orchestrator: cross-domain planning and delegation
+
+Verification:
+- Run repo tests or documented quality gates after edits.
+```
+
+## Rules
+
+- No marketing prose.
+- No duplicated long policy blocks.
+- No stale file paths.
+- If this repo's `plugins/` changes, update `.claude-plugin/marketplace.json` in the same change.

--- a/plugins/ai-workspace-orchestrator/skills/write-project-skill/SKILL.md
+++ b/plugins/ai-workspace-orchestrator/skills/write-project-skill/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: write-project-skill
+description: Create global or project-local agent skills with concise SKILL.md files, progressive disclosure, and optional deterministic scripts. Use when the user wants new skills for a project, workspace, domain, or global AI setup.
+---
+
+# Write Project Skill
+
+Goal: create only the skills that improve future agent performance for repeated work.
+
+## Process
+
+1. Identify scope:
+   - Global: reusable across unrelated projects, placed under the user's global skills directory.
+   - Project-local: tied to this repo/domain, placed under the project's skill/plugin structure and referenced from `AGENTS.md`.
+2. Ask for missing requirements one at a time:
+   - Task/domain covered.
+   - Trigger phrases.
+   - Concrete use cases.
+   - Whether scripts or references are needed.
+3. Draft the skill:
+   - `SKILL.md` with only `name` and `description` in frontmatter.
+   - Body under 100 lines when possible.
+   - References one level deep when details would bloat the main file.
+   - Scripts only for deterministic repeated operations.
+4. Validate:
+   - Description says what the skill does and when to use it.
+   - Name is lowercase hyphen-case.
+   - No stale placeholders.
+   - Script examples run when scripts were added.
+
+## Placement Policy
+
+- Put repo-specific conventions in project-local skills.
+- Put universal workflows in global skills.
+- Do not duplicate the same skill globally and locally; create a global skill plus project references when needed.
+- For plugin work in this repo, update `.claude-plugin/marketplace.json` whenever a plugin directory is added, renamed, or removed.
+
+## Skill Template
+
+```md
+---
+name: skill-name
+description: One sentence describing capability. Use when specific trigger or context applies.
+---
+
+# Skill Name
+
+Goal: short outcome.
+
+## Process
+
+1. Step.
+2. Step.
+3. Verify.
+
+## Rules
+
+- Constraint.
+- Constraint.
+```
+
+## Review Checklist
+
+- Description includes concrete triggers.
+- Body contains workflow, rules, and verification.
+- References are only loaded when needed.
+- Scripts are justified by determinism or repetition.
+- Every created skill maps to a real future task.

--- a/plugins/ai-workspace-orchestrator/skills/write-project-skill/SKILL.md
+++ b/plugins/ai-workspace-orchestrator/skills/write-project-skill/SKILL.md
@@ -33,7 +33,7 @@ Goal: create only the skills that improve future agent performance for repeated 
 - Put repo-specific conventions in project-local skills.
 - Put universal workflows in global skills.
 - Do not duplicate the same skill globally and locally; create a global skill plus project references when needed.
-- For plugin work in this repo, update `.claude-plugin/marketplace.json` whenever a plugin directory is added, renamed, or removed.
+- For plugin work in this repo, update `.claude-plugin/marketplace.json` whenever a plugin directory is added, renamed, removed, or plugin metadata changes.
 
 ## Skill Template
 

--- a/plugins/ai-workspace-orchestrator/templates/AGENTS.md
+++ b/plugins/ai-workspace-orchestrator/templates/AGENTS.md
@@ -1,0 +1,28 @@
+# <Project Name> AI Workspace
+
+## Topology
+
+- Depth: <low|medium|high|max>
+- Scope: <project|global|both>
+- Shape: <single-project|monorepo|multi-repo-domain>
+- Domains: <backend, frontend, mobile, data, infra, docs, security>
+
+## Skills
+
+- `<skill-name>`: <scope and trigger>
+
+## Agents
+
+- `workspace-orchestrator`: owns cross-domain planning, delegation, and synthesis.
+- `<domain-agent>`: owns <domain>.
+
+## Routing
+
+1. Use project evidence before asking setup questions.
+2. Ask one unresolved decision at a time.
+3. Delegate domain work to the matching specialist agent.
+4. Verify each changed domain with its documented command.
+
+## Handoff
+
+Write compact handoffs to the configured temp or project handoff path. Reference artifacts by path instead of duplicating them.

--- a/plugins/ai-workspace-orchestrator/templates/AGENTS.md
+++ b/plugins/ai-workspace-orchestrator/templates/AGENTS.md
@@ -22,6 +22,7 @@
 2. Ask one unresolved decision at a time.
 3. Delegate domain work to the matching specialist agent.
 4. Verify each changed domain with its documented command.
+5. Run `adversarial-setup-review` before merging durable instruction changes.
 
 ## Handoff
 

--- a/plugins/ai-workspace-orchestrator/templates/CLAUDE.md
+++ b/plugins/ai-workspace-orchestrator/templates/CLAUDE.md
@@ -2,4 +2,4 @@
 
 Canonical instructions live in `AGENTS.md`.
 
-If symlinks are supported for this workspace, replace this file with a symlink to `AGENTS.md`. If not, keep this pointer file and do not duplicate the full instruction body.
+If symlinks are supported for this workspace, preserve or migrate any existing `CLAUDE.md` content before replacing this file with a symlink to `AGENTS.md`. If not, keep this pointer file and do not duplicate the full instruction body.

--- a/plugins/ai-workspace-orchestrator/templates/CLAUDE.md
+++ b/plugins/ai-workspace-orchestrator/templates/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Entry Point
+
+Canonical instructions live in `AGENTS.md`.
+
+If symlinks are supported for this workspace, replace this file with a symlink to `AGENTS.md`. If not, keep this pointer file and do not duplicate the full instruction body.


### PR DESCRIPTION
## Summary

Adds the `ai-workspace-orchestrator` plugin for project, monorepo, and domain AI setup. It provides a guided setup wizard, project/global skill creation, Spotify Squad-style agent orchestration, AGENTS.md/CLAUDE.md contract management, adversarial setup review, and compact handoff support.

Registers the plugin in `.claude-plugin/marketplace.json` so the plugin directory and marketplace stay in sync.

## Architecture

```mermaid
flowchart TD
    U[User setup request] --> W[setup-ai-workspace]
    W --> D{Depth}
    D -->|low| C[AGENTS/CLAUDE contract]
    C --> K[workspace-contract]
    D -->|medium| S[Project/global skills]
    D -->|high| A[Workspace orchestrator + subagents]
    D -->|max| M[Domain orchestration + handoff loop]
    S --> K[workspace-contract]
    A --> K
    M --> K
    K --> R[adversarial-setup-review]
    R --> H[context-handoff]
    A --> P[spotify-squad reuse when useful]
```

## Changes

### Plugin
- Adds `plugins/ai-workspace-orchestrator/plugin.json` and Codex manifest metadata.
- Adds plugin-level `AGENTS.md` with the operating model and skill map.
- Adds `workspace-orchestrator` agent for cross-domain setup decisions.

### Skills
- Adds `setup-ai-workspace` for low/medium/high/max setup intake.
- Adds `write-project-skill` for global or project-local skill generation.
- Adds `build-agent-orchestrator` for Spotify Squad-style orchestration.
- Adds `workspace-contract` for AGENTS.md/CLAUDE.md and symlink/pointer strategy.
- Adds `adversarial-setup-review` for principal-engineer review of durable setup changes.
- Adds `context-handoff` for compact continuation docs.

### Marketplace
- Adds the plugin entry to `.claude-plugin/marketplace.json` in sorted order and keeps metadata aligned with `plugin.json`.

## Inspiration

- https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md
- https://github.com/mattpocock/skills/tree/main/skills/productivity/write-a-skill
- https://github.com/mattpocock/skills/blob/main/skills/productivity/handoff/SKILL.md

## Validation

- [x] Plugin validator passed for `plugins/ai-workspace-orchestrator`.
- [x] All 6 skills passed `quick_validate.py`.
- [x] Marketplace invariant passed: 38 plugin dirs, 38 marketplace entries, no missing or stale entries.
- [x] Marketplace ordering check passed.
- [x] Marketplace metadata for `ai-workspace-orchestrator` matches `plugin.json`.
- [x] Agent frontmatter check passed.
- [x] Final 777-pass artifact audit passed across 12 required plugin files.

## Impact

- Breaking changes: No.
- Migrations required: None.
- Environment variables: None changed.
- Affected areas: plugin registry and new AI workspace orchestration plugin.
