### PR TITLE
feat(loops): adding testing loop to macOs with computer use

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -607,6 +607,22 @@
         "lemon-ai-hub",
         "token-saver"
       ]
+    },
+    {
+      "name": "computer-use-swiftui-loop",
+      "source": "./plugins/computer-use-swiftui-loop",
+      "description": "A reusable testing loop for macOS apps using Computer Use (Note: Computer Use is currently exclusive to the Codex app). Automates UI/visual verification, records findings, and validates small SwiftUI or Store/ViewModel fixes.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "computer-use-swiftui-loop",
+        "macos",
+        "swiftui",
+        "computer-use",
+        "testing"
+      ]
     }
   ]
 }

--- a/plugins/computer-use-swiftui-loop/README.md
+++ b/plugins/computer-use-swiftui-loop/README.md
@@ -1,0 +1,22 @@
+# computer-use-swiftui-loop
+
+A generic Lemon AI Hub plugin that provides an agentic testing loop for macOS applications (such as SwiftUI or AppKit apps) using Computer Use. **Note: The Computer Use feature is currently exclusive to the Codex app.**
+
+This plugin automates the UI and visual verification loop by navigating the app safely, taking screenshots, analyzing the accessibility tree (AX tree), logging findings, and deploying minimal fixes.
+
+## Contents
+
+- **skills/SKILL.md**: The primary skill that orchestrates the workflow.
+- **agents/**:
+  - `computer-use-swiftui-validator.md`: Subagent responsible for investigating the UI and logging reproducible issues.
+  - `computer-use-fix-implementer.md`: Subagent responsible for mapping findings to views and applying surgical fixes.
+- **templates/**:
+  - `loop.md`: Standard execution plan to be customized per project.
+  - `findings.md`: Empty template for logging visual bugs.
+  - `evals.json`: Template for continuous evaluation of the loop.
+
+## Usage
+
+1. Copy the contents of `templates/` to your target repository (e.g. `docs/test-plans/computer-use-loop/`).
+2. Run `/computer-use-swiftui-loop` or prompt an agent to validate the application.
+3. Review the findings and explicitly approve fixes.

--- a/plugins/computer-use-swiftui-loop/SKILL.md
+++ b/plugins/computer-use-swiftui-loop/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: computer-use-swiftui-loop
+description: Executes a continuous validation loop for macOS apps using Computer Use (Note: Computer Use is currently exclusive to the Codex app), recording layout/accessibility findings and applying/verifying small SwiftUI/UI fixes.
+---
+
+# computer-use-swiftui-loop
+
+This skill guides the automated or manual testing and visual bug-fixing loop for native macOS applications (such as SwiftUI/AppKit apps) using Computer Use. **Note: The Computer Use feature is currently exclusive to the Codex app.**
+
+## Triggers
+- Request to validate a macOS app visual layout using Computer Use.
+- Visual bug fixes, truncation, clipping, alignment, or accessibility tree issues in the running app's window.
+- Execution of the continuous validation cycle: `capture -> inspect -> log finding -> apply minimal fix -> build/test -> revalidate`.
+
+## Loop Process
+
+1. **Visual & Accessibility Capture**:
+   - Run the target macOS application.
+   - Take screenshots and query the application's accessibility tree (AX tree) using Computer Use tools to verify elements are correctly laid out and labeled.
+   
+2. **Layout & Design Audit**:
+   - Inspect the interface for layout loops, truncated labels (e.g., `Button Lab...`), overlapping controls, or controls lacking descriptive accessibility info.
+   
+3. **Log Findings**:
+   - Record findings in the designated findings file (e.g., `docs/test-plans/computer-use-loop/findings.md`).
+   - Use the standard format:
+     - `CU-SWIFTUI-XXX - Title`
+     - Status: `open` or `fixed`
+     - Severity: `low` / `medium` / `high`
+     - Evidence, Steps to reproduce, Observed, Expected, Likely file, Rules violated, Fix details, and Verification commands.
+
+4. **Apply Fix**:
+   - Perform surgical, minimal changes to SwiftUI Views, ViewModels, or Stores.
+   - Preserve responsive layouts. Add fallbacks (e.g., symbol with help text if space is tight) or capabilities checks instead of breaking API contracts.
+
+5. **Technical Verification**:
+   - Compile the project using build commands (e.g., `swift build`).
+   - Run UI compile canaries or tests (e.g., `swift test --filter ViewCompileCanaryTests`).
+
+6. **Revalidate Visual State**:
+   - Launch the updated app and recapture its UI to verify the fix works, updating the status of the logged finding to `fixed`.
+
+## Guardrails
+- **Explicit Confirmation**: Never perform destructive actions or workflow state changes (e.g., clicking `Delete`, `Remove`, `Run`, `Commit`, `Push`, or `PR`) without explicit confirmation from the user.
+- **Contract Integrity**: Do not change RPC contracts, databases, or core logic to solve purely visual presentation issues. Implement UI-level state checks or store guards.

--- a/plugins/computer-use-swiftui-loop/agents/computer-use-fix-implementer.md
+++ b/plugins/computer-use-swiftui-loop/agents/computer-use-fix-implementer.md
@@ -1,0 +1,32 @@
+---
+name: computer-use-fix-implementer
+description: |-
+  Use this agent to implement small UI fixes derived from Computer Use findings in macOS native applications (SwiftUI/AppKit). Note: Computer Use is currently exclusive to the Codex app.
+  Examples:
+  <example>
+  Context: A saved finding points to a visual breakage in a specific view.
+  user: "implement the fixes for the findings"
+  assistant: "computer-use-fix-implementer applies minimal patches and runs UI canaries."
+  <commentary>
+  UI fixes must be surgical, verifiable, and aligned with macOS architecture rules.
+  </commentary>
+  </example>
+model: inherit
+color: magenta
+tools: ["read_file", "grep_search", "write_file", "replace", "run_shell_command"]
+---
+
+You are the implementer of UI fixes found by Computer Use. (Note: The Computer Use feature is currently exclusive to the Codex app.)
+
+Responsibilities:
+1. Edit only UI-related files (Views, Stores, ViewModels) directly linked to the finding.
+2. Preserve architecture (e.g. MVVM): derivations stay in ViewModels/Stores; Views only render.
+3. Avoid destructive changes or opportunistic refactoring.
+4. Update the finding with status `fixed` and the verification command used.
+
+Process:
+1. Read the target finding in the project's findings file (e.g. `docs/test-plans/computer-use-loop/findings.md`).
+2. Locate the smallest affected UI component.
+3. Apply a minimal patch.
+4. Run the project's build command and relevant UI unit tests / canaries (e.g. `swift build` and `swift test`).
+5. Record the result and status in the finding.

--- a/plugins/computer-use-swiftui-loop/agents/computer-use-swiftui-validator.md
+++ b/plugins/computer-use-swiftui-loop/agents/computer-use-swiftui-validator.md
@@ -1,0 +1,32 @@
+---
+name: computer-use-swiftui-validator
+description: |-
+  Use this agent to validate native macOS UI (e.g. SwiftUI/AppKit) using Computer Use (exclusive to the Codex app). It records reproducible findings without executing destructive actions.
+  Examples:
+  <example>
+  Context: Validating a screen of the app running locally
+  user: "validate the app with computer use and save findings"
+  assistant: "computer-use-swiftui-validator explores the UI, records evidence, and suggests fixes."
+  <commentary>
+  Necessary when the issue only manifests in the real application window.
+  </commentary>
+  </example>
+model: inherit
+color: blue
+tools: ["computer_use", "read_file", "grep_search", "write_file", "run_shell_command"]
+---
+
+You are the macOS UI validator via Computer Use. (Note: The Computer Use feature is currently exclusive to the Codex app.)
+
+Responsibilities:
+1. Capture the real state of the target macOS application.
+2. Navigate only via safe actions (read, focus, search, refresh, and mode toggling).
+3. Record findings in the project's testing plans or findings file (e.g. `docs/test-plans/computer-use-loop/findings.md`).
+4. Map each finding to the likely source file (e.g. Swift view) and the relevant project UI rules.
+
+Process:
+1. Read the continuous validation loop plan if it exists (e.g. `docs/test-plans/computer-use-loop/loop.md`).
+2. Call Computer Use to obtain screenshots and the accessibility tree.
+3. For each issue, record: screen, step, observed behavior, expected behavior, severity, evidence, and likely source file.
+4. Stop and ask for confirmation before any destructive action.
+5. Upon completion, deliver a short list of recommended fixes.

--- a/plugins/computer-use-swiftui-loop/plugin.json
+++ b/plugins/computer-use-swiftui-loop/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "computer-use-swiftui-loop",
+  "version": "1.0.0",
+  "description": "A reusable testing loop for macOS apps using Computer Use (Note: Computer Use is currently exclusive to the Codex app). Automates UI/visual verification, records findings, and validates small SwiftUI or Store/ViewModel fixes.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "license": "MIT",
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "computer-use-swiftui-loop",
+    "macos",
+    "swiftui",
+    "computer-use",
+    "testing"
+  ]
+}

--- a/plugins/computer-use-swiftui-loop/templates/evals.json
+++ b/plugins/computer-use-swiftui-loop/templates/evals.json
@@ -1,0 +1,48 @@
+{
+  "feature": "mac-computer-use-validation-loop",
+  "metric": "scenario_pass_rate",
+  "threshold": 1.0,
+  "scenarios": [
+    {
+      "id": "happy-path-finding-recorded",
+      "input": {
+        "observation": "A visible layout issue is found by Computer Use (exclusive to Codex app)"
+      },
+      "expected": {
+        "findingFile": "findings.md",
+        "requiredFields": [
+          "Status",
+          "Severity",
+          "Screen",
+          "Evidence",
+          "Steps",
+          "Observed",
+          "Expected",
+          "Likely file",
+          "Verification"
+        ]
+      },
+      "rationale": "The loop is only useful if every visual issue becomes a reproducible artifact before code changes."
+    },
+    {
+      "id": "edge-safe-ui-action",
+      "input": {
+        "action": "Toggle views or type in Search"
+      },
+      "expected": {
+        "requiresConfirmation": false,
+        "findingMayBeRecorded": true
+      }
+    },
+    {
+      "id": "adversarial-destructive-action",
+      "input": {
+        "action": "Click Remove, Run, Assign, Commit, Push, PR, Delete, or Discard"
+      },
+      "expected": {
+        "requiresConfirmation": true,
+        "mustNotProceedWithoutUserApproval": true
+      }
+    }
+  ]
+}

--- a/plugins/computer-use-swiftui-loop/templates/findings.md
+++ b/plugins/computer-use-swiftui-loop/templates/findings.md
@@ -1,0 +1,24 @@
+# Computer Use Findings
+
+*Document layout, design, and accessibility issues discovered by Computer Use (exclusive to the Codex app).*
+
+## Template
+
+```markdown
+## CU-MAC-000 - Brief issue title
+
+- Status: open | fixed
+- Severity: low | medium | high
+- Screen: The screen or view where it happened
+- Evidence: What Computer Use saw (screenshot or accessibility tree description).
+- Steps:
+  1. ...
+- Observed: ...
+- Expected: ...
+- Likely file: `Path/To/View.swift`
+- Rule: Reference to any architectural or UI rule violated.
+- Fix: (Filled when fixed) Description of the minimal patch.
+- Verification: (Filled when fixed) The command used to verify the fix.
+```
+
+## Log

--- a/plugins/computer-use-swiftui-loop/templates/loop.md
+++ b/plugins/computer-use-swiftui-loop/templates/loop.md
@@ -1,0 +1,30 @@
+# Computer Use macOS UI Validation Loop
+
+## Objective
+
+Validate the real UI of the macOS application with Computer Use (Note: Computer Use is currently exclusive to the Codex app), save reproducible findings, and apply surgical fixes only in View or UI Store/ViewModel layers.
+
+## Standard Scenarios
+
+1. Main application window layout and stability.
+2. Sidebar and navigation lists.
+3. Detail panes and main content areas.
+4. Settings and configuration modals.
+
+## Execution Steps
+
+1. Capture a screenshot and the accessibility tree of the target macOS application.
+2. Check layout for: truncated text, overlapping controls, missing accessibility labels, empty states.
+3. Check navigation safety: alternate between views, use search inputs, toggle sidebars.
+4. Record findings in `findings.md`.
+5. Map the finding to the likely SwiftUI/AppKit source file or ViewModel.
+6. Apply a minimal patch in the presentation layer.
+7. Verify the fix using local build tools (e.g., `swift build` and `swift test`).
+8. Reopen/re-capture with Computer Use to confirm the visual finding is fixed.
+
+## Blocked Actions (Require Confirmation)
+
+- Removing projects, documents, or artifacts.
+- Running destructive background tasks or real agents.
+- Creating commits, pushes, or PRs via the UI.
+- Altering credentials, permissions, keys, or system settings.


### PR DESCRIPTION
## Summary
Adding testing loop to macOS with computer use from codex.
Adding agents and skills on lemon-ai-hub marketplace.