### PR TITLE
feat: add 7 productivity & engineering plugins from Matt Pocock skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
     {
       "name": "agentic-value-loops",
       "source": "./plugins/agentic-value-loops",
-      "description": "Agentic Value Loops plugin \u2014 Continuous improvement engine that ships verified increments with constant quality. Includes loops for Feature Development, Maintenance & Security, Documentation Sync, and AI Tuning.",
+      "description": "Agentic Value Loops plugin — Continuous improvement engine that ships verified increments with constant quality. Includes loops for Feature Development, Maintenance & Security, Documentation Sync, and AI Tuning.",
       "version": "1.0.0",
       "license": "MIT",
       "keywords": [
@@ -97,7 +97,7 @@
     {
       "name": "api-test-loop",
       "source": "./plugins/api-test-loop",
-      "description": "API Test Loop plugin \u2014 Automated REST API validation loop. Executes HTTP requests via CURL, logs findings for REST best practices (method, input/output format, security, performance, docs), and implements backend fixes.",
+      "description": "API Test Loop plugin — Automated REST API validation loop. Executes HTTP requests via CURL, logs findings for REST best practices (method, input/output format, security, performance, docs), and implements backend fixes.",
       "version": "1.0.0",
       "license": "MIT",
       "keywords": [
@@ -157,6 +157,23 @@
       ]
     },
     {
+      "name": "architecture-deepener",
+      "source": "./plugins/architecture-deepener",
+      "description": "Superficia oportunidades de deepening — refactors que transformam módulos shallow em deep. Testabilidade e AI-navigability. Relatório HTML visual com before/after + grilling loop via /grilling e domain-modeling integration. Baseado em improve-codebase-architecture de Matt Pocock.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "architecture",
+        "refactoring",
+        "deepening",
+        "modules",
+        "testability",
+        "code-quality"
+      ]
+    },
+    {
       "name": "async-advisor",
       "source": "./plugins/async-advisor",
       "description": "Async and concurrency static analysis plugin. Scans TypeScript/JavaScript codebases for race conditions, unbounded Promise.all, missing AbortController, swallowed rejections, and N+1 async patterns. Runs as a pre-commit hook or CI check and provides inline fix suggestions.",
@@ -187,6 +204,23 @@
         "skill",
         "lemon-ai-hub",
         "async-patterns"
+      ]
+    },
+    {
+      "name": "bug-diagnostics",
+      "source": "./plugins/bug-diagnostics",
+      "description": "Loop de diagnóstico para bugs difíceis e regressões de performance. 6 fases: feedback loop tight → reprodução → hipóteses falsificáveis → instrumentação → fix + teste de regressão → cleanup + post-mortem. Baseado em diagnosing-bugs de Matt Pocock.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "debugging",
+        "diagnostics",
+        "bugs",
+        "performance-regression",
+        "feedback-loop",
+        "bisection"
       ]
     },
     {
@@ -351,7 +385,7 @@
     {
       "name": "code-smell",
       "source": "./plugins/code-smell",
-      "description": "Code smell detection and remediation. Identifies long methods, god classes, feature envy, primitive obsession, shotgun surgery, dead code, magic numbers, and other structural anti-patterns. Goes beyond linters \u2014 understands semantic coupling and design intent. Use when code is hard to change, PRs are consistently risky, or technical debt is growing faster than features.",
+      "description": "Code smell detection and remediation. Identifies long methods, god classes, feature envy, primitive obsession, shotgun surgery, dead code, magic numbers, and other structural anti-patterns. Goes beyond linters — understands semantic coupling and design intent. Use when code is hard to change, PRs are consistently risky, or technical debt is growing faster than features.",
       "version": "1.0.0",
       "license": "MIT",
       "keywords": [
@@ -482,6 +516,23 @@
       ]
     },
     {
+      "name": "doc-driven-grilling",
+      "source": "./plugins/doc-driven-grilling",
+      "description": "Interrogatório implacável para planos/designs que cria docs (ADRs, glossário CONTEXT.md) durante o processo. Integra /grilling + /domain-modeling. Captura decisões no momento exato, não em batch. Baseado em grill-with-docs de Matt Pocock.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "documentation",
+        "grilling",
+        "adr",
+        "domain-modeling",
+        "glossary",
+        "design-docs"
+      ]
+    },
+    {
       "name": "feature-flag",
       "source": "./plugins/feature-flag",
       "description": "Feature flag implementation, management, and cleanup. Handles flag creation, gradual rollout strategies, A/B testing wiring, stale flag detection, and safe flag removal. Supports LaunchDarkly, Unleash, GrowthBook, Statsig, custom env-var flags, and database-backed toggles. Use when adding gated features, rolling out gradually, or cleaning up old flags.",
@@ -515,7 +566,7 @@
     {
       "name": "feature-purge",
       "source": "./plugins/feature-purge",
-      "description": "Safely remove an entire feature and every dead reference it leaves behind \u2014 not just the folder you point at, but the sibling folders in other architecture layers, the imports/registries/routes/i18n keys that point to it, and any newly-orphaned code. Verifies the quality gate stays 100% green and writes a Markdown removal report. Use when deleting a feature, screen, module, or directory and you need it gone WITHOUT leaving dead files or dead code. Triggers on /feature-purge <path>, \"remove this feature\", \"delete this folder safely\", \"apaga essa feature sem deixar c\u00f3digo morto\", \"limpa essa screen e as camadas\".",
+      "description": "Safely remove an entire feature and every dead reference it leaves behind — not just the folder you point at, but the sibling folders in other architecture layers, the imports/registries/routes/i18n keys that point to it, and any newly-orphaned code. Verifies the quality gate stays 100% green and writes a Markdown removal report. Use when deleting a feature, screen, module, or directory and you need it gone WITHOUT leaving dead files or dead code. Triggers on /feature-purge <path>, \"remove this feature\", \"delete this folder safely\", \"apaga essa feature sem deixar código morto\", \"limpa essa screen e as camadas\".",
       "version": "1.0.0",
       "license": "MIT",
       "keywords": [
@@ -923,7 +974,7 @@
     {
       "name": "senior-prompt-engineer",
       "source": "./plugins/senior-prompt-engineer",
-      "description": "Pipeline stage-0 prompt refiner. Runs FIRST \u2014 before skills-selector and smart-dispatch \u2014 turning a raw idea, pasted draft, or the current chat into a definitive, production-grade prompt (Anthropic prompt-engineering best practices), then hands the refined prompt + an Execution Map (agents, skills, models, effort, time & token estimate) to the routers so they pick the best skills/models with sharpened context. When no file path is given, the input IS the chat/pasted text and the output is returned inline (processed naturally), not forced to a file. Use when the user invokes /senior-prompt-engineer, says \"refine my prompt\", \"improve this prompt\", \"turn this idea into a prompt\", \"rewrite idea.md to prompt.md\", \"definitive prompt\", \"professional prompt\", or pastes a draft prompt/idea to be hardened. Cross-CLI: Claude, Codex, Gemini, OpenCode, Antigravity (agy), lemon-code (lemon).",
+      "description": "Pipeline stage-0 prompt refiner. Runs FIRST — before skills-selector and smart-dispatch — turning a raw idea, pasted draft, or the current chat into a definitive, production-grade prompt (Anthropic prompt-engineering best practices), then hands the refined prompt + an Execution Map (agents, skills, models, effort, time & token estimate) to the routers so they pick the best skills/models with sharpened context. When no file path is given, the input IS the chat/pasted text and the output is returned inline (processed naturally), not forced to a file. Use when the user invokes /senior-prompt-engineer, says \"refine my prompt\", \"improve this prompt\", \"turn this idea into a prompt\", \"rewrite idea.md to prompt.md\", \"definitive prompt\", \"professional prompt\", or pastes a draft prompt/idea to be hardened. Cross-CLI: Claude, Codex, Gemini, OpenCode, Antigravity (agy), lemon-code (lemon).",
       "version": "1.0.0",
       "license": "MIT",
       "keywords": [
@@ -933,9 +984,42 @@
       ]
     },
     {
+      "name": "session-handoff",
+      "source": "./plugins/session-handoff",
+      "description": "Compacta a conversa atual em documento de handoff para outro agent continuar sem perder contexto. Redige dados sensíveis (API keys, senhas, PII). Inclui seção de skills sugeridas. Salva em tempdir do OS, não no workspace. Baseado em handoff de Matt Pocock.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "handoff",
+        "context-preservation",
+        "session-continuation",
+        "agent-handover",
+        "context-transfer"
+      ]
+    },
+    {
+      "name": "skill-authoring",
+      "source": "./plugins/skill-authoring",
+      "description": "Referência completa para criar e editar skills excelentes. Vocabulário e princípios de previsibilidade: invocation (model vs user), information hierarchy, granularity, pruning, leading words, failure modes (6 tipos). GLOSSARY.md separado. Baseado em writing-great-skills de Matt Pocock.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "skill-creation",
+        "skill-authoring",
+        "predictability",
+        "invocation",
+        "determinism",
+        "context-load"
+      ]
+    },
+    {
       "name": "skills-selector",
       "source": "./plugins/skills-selector",
-      "description": "Meta-skill gatekeeper that runs FIRST on every task to decide which other skill(s) \u2014 if any \u2014 should activate. Analyzes the user request, matches it against a ranked catalog (frontend-design, ui-ux-pro-max, superpowers/planning, git-*, mcp-builder, smart-dispatch, claude-api, etc.), and emits a tight SELECTION plan so other skills are loaded on-demand only. Minimizes token/context consumption by refusing to activate heavy skills unless clearly justified. Triggers on ANY user instruction that could plausibly benefit from a specialized skill \u2014 i.e. essentially every turn that starts new work. Keywords: \"plan\", \"design\", \"ui\", \"ux\", \"implement\", \"build\", \"create\", \"fix\", \"refactor\", \"commit\", \"pr\", \"review\", \"test\", \"debug\", \"deploy\", \"mobile\", \"video\", \"mcp\", \"skill\", \"architecture\", \"api\", \"ci\", \"docs\", \"copy\", \"social\", \"setup\", \"doctor\".",
+      "description": "Meta-skill gatekeeper that runs FIRST on every task to decide which other skill(s) — if any — should activate. Analyzes the user request, matches it against a ranked catalog (frontend-design, ui-ux-pro-max, superpowers/planning, git-*, mcp-builder, smart-dispatch, claude-api, etc.), and emits a tight SELECTION plan so other skills are loaded on-demand only. Minimizes token/context consumption by refusing to activate heavy skills unless clearly justified. Triggers on ANY user instruction that could plausibly benefit from a specialized skill — i.e. essentially every turn that starts new work. Keywords: \"plan\", \"design\", \"ui\", \"ux\", \"implement\", \"build\", \"create\", \"fix\", \"refactor\", \"commit\", \"pr\", \"review\", \"test\", \"debug\", \"deploy\", \"mobile\", \"video\", \"mcp\", \"skill\", \"architecture\", \"api\", \"ci\", \"docs\", \"copy\", \"social\", \"setup\", \"doctor\".",
       "version": "1.0.0",
       "license": "MIT",
       "keywords": [
@@ -959,7 +1043,7 @@
     {
       "name": "spotify-squad",
       "source": "./plugins/spotify-squad",
-      "description": "AI-Native Squad \u2014 Spotify-model autonomous engineering team. 12 specialized agents (Tech Lead, Backend, Frontend, Mobile, UX, UI, Product, Scrum Master, DevOps, QA, Data, Security) with orchestrated collaboration, domain-specific skills, and cross-functional workflows. Based on the AI Native Developer methodology.",
+      "description": "AI-Native Squad — Spotify-model autonomous engineering team. 12 specialized agents (Tech Lead, Backend, Frontend, Mobile, UX, UI, Product, Scrum Master, DevOps, QA, Data, Security) with orchestrated collaboration, domain-specific skills, and cross-functional workflows. Based on the AI Native Developer methodology.",
       "version": "1.0.0",
       "license": "MIT",
       "keywords": [
@@ -988,6 +1072,23 @@
       ]
     },
     {
+      "name": "task-interrogator",
+      "source": "./plugins/task-interrogator",
+      "description": "Interrogatório implacável para estressar planos e designs antes de implementar. Uma questão por vez, separando fatos (você busca no codebase) de decisões (usuário decide). Só age após confirmação explícita de entendimento compartilhado. Baseado em grill-me e grilling de Matt Pocock.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "interrogation",
+        "grilling",
+        "stress-test",
+        "plan-validation",
+        "design-review",
+        "decision-tree"
+      ]
+    },
+    {
       "name": "teaching",
       "source": "./plugins/teaching",
       "description": "Skill mapping, practice plans, and learning retrospectives. Builds personalized roadmaps with milestones and practice checkpoints, and runs periodic reviews to adjust based on progress.",
@@ -1001,6 +1102,24 @@
         "practice",
         "feedback",
         "mentorship"
+      ]
+    },
+    {
+      "name": "teaching-workspace",
+      "source": "./plugins/teaching-workspace",
+      "description": "Ensina habilidades ou conceitos em workspace stateful. Estrutura: MISSION.md, lessons/*.html (unidades de ensino), reference/*.html (cheat sheets, glossários), learning-records/*.md (ADRs de aprendizado), assets/ (componentes reutilizáveis). Filosofia: knowledge → skills → wisdom, zone of proximal development. Baseado em teach de Matt Pocock.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "teaching",
+        "learning",
+        "education",
+        "skills",
+        "lessons",
+        "workspace",
+        "stateful-learning"
       ]
     },
     {

--- a/plugins/architecture-deepener/SKILL.md
+++ b/plugins/architecture-deepener/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: architecture-deepener
+description: Surface opportunities to deepen a codebase. Finds modules that are shallow (thin pass-throughs, anemic types, missing domain modeling) and proposes how to make them deep (rich domain types, co-located behavior, testable seams). Outputs a visual HTML report and then runs an interactive grilling loop that pressure-tests each opportunity. Use when the codebase feels "flat", domain logic leaks into controllers/UI, types carry no behavior, or AI agents struggle to navigate the module boundaries. Integrates with domain-modeling, codebase-design, and ADR workflows.
+---
+
+# Architecture Deepener
+
+Turn shallow modules into deep ones. Make the codebase navigable for humans and AI agents alike.
+
+Based on **improve-codebase-architecture** by Matt Pocock (https://github.com/mattpocock/skills).
+
+## Core Idea: Shallow vs Deep Modules
+
+A **shallow module** has a broad interface relative to the complexity it hides. It passes data through, delegates immediately, or carries no domain knowledge. It is a wiring artifact, not an abstraction.
+
+A **deep module** has a narrow interface over a large implementation. It hides a hard decision behind a small surface, co-locates behavior with the data it owns, and gives callers something meaningful to say.
+
+```
+SHALLOW                          DEEP
+┌──────────────────────┐         ┌──────────┐
+│ interface (wide)     │         │ interface│
+│  - validate()        │         │  - run() │
+│  - transform()       │         └────┬─────┘
+│  - persist()         │              │
+│  - notify()          │              ▼
+└──────────────────────┘         ┌──────────┐
+  implementation (thin)          │ complex  │
+  - return this.repo.save(x)     │ impl that│
+                                 │ truly    │
+                                 │ hides X  │
+                                 └──────────┘
+```
+
+Deepening is not about adding code. It is about **moving** behavior to where the data lives, so the rest of the system can stay shallow.
+
+## Quick Start
+
+```
+/architecture-deepener                        — analyze cwd, write report, start grilling
+/architecture-deepener --dir src/domain       — scope to a directory
+/architecture-deepener --report-only          — skip grilling, just emit HTML
+/architecture-deepener --grill src/checkout   — skip exploration, grill a known module
+```
+
+## Three Phases
+
+### Phase 1 — Explore (read-only)
+
+Goal: build an evidence-backed map of shallowness across the target scope.
+
+1. **Bound the scope.** Default: project root (respect `.gitignore`). Override with `--dir`.
+2. **Enumerate modules.** A "module" is a file or cohesive directory that exports a unit (class, factory, service, component, route handler).
+3. **For each module, collect signals:**
+   - **Interface surface**: count exported members. Wide surface + thin body = shallow.
+   - **Pass-through ratio**: how many functions just forward args to the next call (`return this.x.foo(...args)`).
+   - **Anemic types**: types/interfaces that only declare shape and carry zero methods/functions.
+   - **Domain logic in the wrong layer**: business rules living in controllers, UI components, or CLI handlers instead of domain modules.
+   - **Primitive obsession at boundaries**: `string`, `number`, bare arrays used where a value object would carry meaning and invariants.
+   - **AI-navigability**: can an agent jump to this module from a symptom ("where is the rule for X?") without reading 5 wiring files? Score 1-5.
+4. **Classify** each module: `deep`, `balanced`, `shallow`, `anemic`, `leaky`.
+5. **Rank** by deepening payoff = (impact of the hidden complexity) x (effort to move it). Prefer changes that unblock tests and AI navigation.
+6. **Persist raw findings** to memory/context for the report phase. Do not emit prose yet.
+
+Exit criteria: every module tagged, top 5-10 opportunities ranked with one-line rationale each.
+
+### Phase 2 — HTML Report (artifact)
+
+Goal: produce a single self-contained `architecture-deepener-report.html` that a human can scan in 60 seconds and an agent can cite.
+
+Write the file with the native Write tool. The report MUST contain:
+
+- **Header**: project name, scope, date, counts (modules scanned, shallow count, deep count).
+- **Shallowness heatmap**: a table or grid where each row is a module, columns are the signals from Phase 1, cells are color-coded:
+  - green = deep / healthy
+  - yellow = balanced / watch
+  - red = shallow / anemic / leaky
+- **Top opportunities**: the ranked list with, for each:
+  - module path
+  - current shape (one sentence + the signal that proves it)
+  - proposed deep shape (one sentence: what moves where)
+  - payoff score + effort estimate (S/M/L)
+  - testability delta: what becomes testable after the change that is not testable today
+  - AI-navigability delta: what an agent can now locate directly
+- **Before/After sketch**: an ASCII or `<svg>` diagram for the top 1-2 opportunities showing behavior moving from a controller/wiring layer into the domain module.
+- **Integration notes**: explicit hooks into `domain-modeling`, `codebase-design`, and ADR workflows (see below).
+- **Footer**: credit line — `Based on improve-codebase-architecture by Matt Pocock (https://github.com/mattpocock/skills)`.
+
+Keep it dependency-free: inline `<style>`, no external scripts, no network calls. It must render by opening the file directly.
+
+### Phase 3 — Grilling Loop (interactive)
+
+Goal: pressure-test each top opportunity before anyone writes code. Do not trust the first proposal.
+
+For each ranked opportunity, run this loop (max 3 rounds per item, then move on):
+
+1. **State the proposal** in one sentence: "Move X behavior from A into B."
+2. **Grill yourself** with these questions, in order. Answer each concretely with file paths and types, not vibes:
+   - **What concrete bug or test-gap does this fix that exists today?** If you cannot name one, the change is speculative — demote it.
+   - **Who are the callers, and what must they change?** Enumerate every import site. A "deepening" that ripples through 20 callers is usually wrong; a better intermediate step exists.
+   - **What invariant does the deeper module enforce that nothing enforces today?** Name the rule. If there is no new invariant, you are moving code, not deepening it.
+   - **Does this collapse or create a layer?** Deepening should remove a layer or a pass-through, not add scaffolding. If it adds a layer, justify why the indirection pays for itself.
+   - **Can an AI agent now navigate to this module from a symptom without reading wiring files?** Give the symptom-to-module path. This is the AI-navigability test.
+   - **What is the smallest version of this change that still delivers the invariant?** Cut scope until it hurts, then cut once more.
+3. **Update the proposal** based on the answers. Common outcomes:
+   - Proposal survives — promote to an actionable card.
+   - Proposal shrinks — re-rank with the smaller scope.
+   - Proposal dies — mark it `rejected: <reason>` in the report and move on. A kill is a successful outcome.
+4. **Exit the loop** when the proposal is either promoted or killed. Never leave one lingering.
+
+After all top items are processed, emit a final **action list**:
+- `PROMOTE` items: module, invariant gained, smallest first step, estimated effort.
+- `REJECTED` items: module, one-line reason.
+- `DEFERRED` items: module, what needs to become true first (an ADR, a missing type, a test).
+
+## Shallow vs Deep — Recognition Cheatsheet
+
+| Signal | Shallow | Deep |
+|--------|---------|------|
+| Exports | Many, ad-hoc | Few, cohesive |
+| Function bodies | `return this.x.foo(...)` | Encodes a domain rule |
+| Types | Shape-only interfaces | Types with behavior / invariants |
+| Where rules live | Controller / UI / CLI | Domain module |
+| Tests | Need full stack to test | Unit-testable in isolation |
+| AI navigation | "Where is the rule for X?" → 5 hops | Symptom → module in 1 hop |
+| Change ripple | One rule change → N files | One rule change → 1 file |
+
+## Integration
+
+- **domain-modeling**: When an opportunity is "anemic type", hand to domain-modeling to design the rich type and its invariants before moving code.
+- **codebase-design**: When an opportunity collapses or creates a layer, log it in the codebase-design record so the layering decision is explicit and reviewable.
+- **ADRs**: Any `PROMOTE` item that changes a cross-cutting invariant or layering boundary gets a short ADR (Architecture Decision Record) capturing the before/after and the grilling answers. Do not let an invariant move silently.
+
+## Guardrails
+
+- **Read-only until Phase 3 ends.** Exploration and report never edit source.
+- **No speculative generality.** If you cannot name the concrete bug, test-gap, or invariant gained, the change does not ship.
+- **Smallest first step.** Every promoted item has a single smallest first step. Do not batch.
+- **Kill is success.** A rejected opportunity that saves a team from a bad refactor is a win. Record it.
+- **Effort honesty.** Do not label a 20-caller ripple as effort `S`. If the honest answer is `L`, say so and defer.
+
+## Output Artifacts
+
+| Artifact | Path | Phase |
+|----------|------|-------|
+| Raw findings map | in-memory / context store | 1 |
+| Visual report | `architecture-deepener-report.html` (project root, or `--out <path>`) | 2 |
+| Action list | appended to the report + echoed to chat | 3 |
+
+## Credit
+
+Based on **improve-codebase-architecture** by Matt Pocock (https://github.com/mattpocock/skills). The shallow/deep framing and the pressure-test-before-refactor discipline are adapted from that work.

--- a/plugins/architecture-deepener/plugin.json
+++ b/plugins/architecture-deepener/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "architecture-deepener",
+  "displayName": "Architecture Deepener",
+  "version": "2.0.0",
+  "description": "Surface opportunities to deepen a codebase. Finds shallow modules (thin pass-throughs, anemic types, domain logic leaking into controllers/UI) and proposes deep modules that co-locate behavior with data, enforce invariants, and stay navigable for humans and AI agents. Emits a visual HTML report and runs an interactive grilling loop that pressure-tests each opportunity before any code moves. Integrates with domain-modeling, codebase-design, and ADR workflows.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "homepage": "https://github.com/mattpocock/skills",
+  "repository": "https://github.com/mattpocock/skills",
+  "license": "MIT",
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "architecture-deepener",
+    "architecture",
+    "refactoring",
+    "deepening",
+    "modules",
+    "testability",
+    "code-quality"
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "architecture",
+    "refactoring",
+    "deepening",
+    "modules",
+    "testability",
+    "code-quality",
+    "domain-modeling",
+    "ai-navigability"
+  ],
+  "skills": "./"
+}

--- a/plugins/bug-diagnostics/SKILL.md
+++ b/plugins/bug-diagnostics/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: bug-diagnostics
+description: Loop de diagnóstico para bugs difíceis e regressões de performance. Feedback loop → reprodução → hipóteses → instrumentação → fix + teste → cleanup. Use quando o usuário disser "diagnosticar"/"debugar isso", ou relatar algo quebrado/lançando exceção/falhando/lento.
+---
+
+# Bug Diagnostics
+
+Uma disciplina para bugs difíceis. Pule fases apenas quando justificado explicitamente.
+
+> **Créditos**: Baseado em `diagnosing-bugs` por [Matt Pocock](https://github.com/mattpocock/skills/tree/main/skills/engineering/diagnosing-bugs). Adaptado para português BR pelo Lemon AI Hub.
+
+Ao explorar o codebase, leia o `CONTEXT.md` (se existir) para construir um modelo mental claro dos módulos relevantes, e consulte ADRs na área que vai mexer.
+
+## Foco
+
+Dois princípios não-negociáveis:
+
+1. **Feedback loop tight** — um sinal de pass/fail que fica vermelho _neste_ bug. Sem loop, debugging é adivinhação.
+2. **Determinismo** — mesmo veredito a cada execução. Bugs não-determinísticos devem ter a taxa de reprodução elevada até serem debugáveis.
+
+---
+
+## Fase 1 — Construir o feedback loop
+
+**Esta é a habilidade.** Todo o resto é mecânico. Se você tem um sinal de pass/fail **tight** para o bug — um que fica vermelho _neste_ bug — você vai encontrar a causa; bisection, teste de hipóteses e instrumentação apenas o consomem. Se não tem, nenhuma quantidade de olhar código vai salvar.
+
+Invista esforço desproporcional aqui. **Seja agressivo. Seja criativo. Recuse-se a desistir.**
+
+### Maneiras de construir um loop — tente nesta ordem aproximada
+
+1. **Teste falhando** em qualquer seam que alcance o bug — unit, integration, e2e.
+2. **Script curl/HTTP** contra um dev server rodando.
+3. **Invocação CLI** com um input fixture, fazendo diff do stdout contra um snapshot conhecido-bom.
+4. **Script headless browser** (Playwright/Puppeteer) — drive a UI, asserta em DOM/console/network.
+5. **Replay de trace capturado.** Salve uma network request/payload/event log real em disco; faça replay pelo code path isolado.
+6. **Harness descartável.** Suba um subset mínimo do sistema (um serviço, deps mockadas) que exercita o code path do bug com uma única chamada de função.
+7. **Loop property/fuzz.** Se o bug é "output às vezes errado", rode 1000 inputs aleatórios e procure o failure mode.
+8. **Harness de bisection.** Se o bug apareceu entre dois estados conhecidos (commit, dataset, versão), automatize "boot no estado X, verifica, repete" para poder fazer `git bisect run`.
+9. **Loop diferencial.** Rode o mesmo input em versão-antiga vs versão-nova (ou duas configs) e faça diff dos outputs.
+10. **Script bash HITL.** Último recurso. Se um humano precisa clicar, _orquestre_ com `scripts/hitl-loop.template.sh` para que o loop ainda seja estruturado. Output capturado alimenta de volta para você.
+
+Construa o feedback loop certo, e o bug está 90% resolvido.
+
+### Tighten o loop
+
+Trate o loop como um produto. Assim que tiver _um_ loop, **tighten**:
+
+- Posso deixar mais rápido? (Cache de setup, pular init irrelevante, estreitar escopo do teste.)
+- Posso deixar o sinal mais nítido? (Assertar no sintoma específico, não em "não crashou".)
+- Posso deixar mais determinístico? (Pinar tempo, seedar RNG, isolar filesystem, congelar network.)
+
+Um loop flaky de 30 segundos é quase tão ruim quanto nenhum loop; um determinístico de 2 segundos é tight — um superpoder de debugging.
+
+### Bugs não-determinísticos
+
+O objetivo não é uma repro limpa, mas sim uma **taxa de reprodução mais alta**. Loope o gatilho 100×, paralelize, adicione stress, estreite janelas de timing, injete sleeps. Um bug 50% flaky é debugável; 1% não é — continue elevando a taxa até ser debugável.
+
+### Quando você genuinamente não consegue construir um loop
+
+Pare e diga explicitamente. Liste o que tentou. Peça ao usuário por: (a) acesso a qualquer ambiente que reproduza, (b) um artifact capturado (HAR file, log dump, core dump, screen recording com timestamps), ou (c) permissão para adicionar instrumentação temporária em produção. **Não** prossiga para hipóteses sem um loop.
+
+### Critério de conclusão — um loop tight que fica vermelho
+
+A Fase 1 está completa quando o loop é **tight** e **red-capable**: você consegue nomear **um comando** — um path de script, uma invocação de teste, um curl — que você **já executou pelo menos uma vez** (cole a invocação e seu output), e que é:
+
+- [ ] **Red-capable** — drive o code path real do bug e asserta o **sintoma exato do usuário**, de forma que possa ficar vermelho neste bug e verde quando corrigido. Não "roda sem erroar" — deve conseguir _pegar este bug específico_.
+- [ ] **Determinístico** — mesmo veredito a cada execução (bugs flaky: taxa de reprodução alta e pinada, conforme acima).
+- [ ] **Rápido** — segundos, não minutos.
+- [ ] **Agent-runnable** — roda sem supervisão; humano no loop apenas via `scripts/hitl-loop.template.sh`.
+
+Se se pegar lendo código para construir uma teoria antes deste comando existir, **pare — pular direto para hipótese é a falha exata que esta skill previne.** Sem comando red-capable, sem Fase 2.
+
+---
+
+## Fase 2 — Reproduzir + minimizar
+
+Rode o loop. Veja ficar vermelho — o bug aparece.
+
+Confirme:
+
+- [ ] O loop produz o failure mode que o **usuário** descreveu — não um failure diferente que acontece de estar próximo. Bug errado = fix errado.
+- [ ] O failure é reproduzível em múltiplas execuções (ou, para bugs não-determinísticos, reproduzível em taxa alta o suficiente para debugar).
+- [ ] Você capturou o sintoma exato (mensagem de erro, output errado, timing lento) para que fases posteriores possam verificar que o fix realmente resolve.
+
+### Minimizar
+
+Assim que estiver vermelho, encolha a repro para o **menor cenário que ainda fica vermelho**. Corte inputs, callers, config, dados e steps **um de cada vez**, re-rodando o loop após cada corte — mantenha apenas o que é load-bearing para o failure.
+
+Por que importa: uma repro mínima encolhe o espaço de hipóteses na Fase 3 (menos partes móveis para suspeitar) e se torna o teste de regressão limpo na Fase 5.
+
+Completo quando **todo elemento restante é load-bearing** — remover qualquer um deles faz o loop ficar verde.
+
+Não prossiga até ter reproduzido **e** minimizado.
+
+---
+
+## Fase 3 — Hipóteses
+
+Gere **3–5 hipóteses ranqueadas** antes de testar qualquer uma. Geração de hipótese única ancora na primeira ideia plausível.
+
+Cada hipótese deve ser **falsificável**: declare a predição que ela faz.
+
+> Formato: "Se <X> é a causa, então <mudar Y> vai fazer o bug desaparecer / <mudar Z> vai piorar."
+
+Se não consegue declarar a predição, a hipótese é um chute — descarte ou afie.
+
+**Mostre a lista ranqueada ao usuário antes de testar.** Ele costuma ter conhecimento de domínio que re-ranqueia instantaneamente ("acabamos de deployar uma mudança em #3"), ou sabe hipóteses que já descartou. Checkpoint barato, grande economia de tempo. Não bloqueie — prossiga com seu ranking se o usuário estiver AFK.
+
+---
+
+## Fase 4 — Instrumentar
+
+Cada probe deve mapear para uma predição específica da Fase 3. **Mude uma variável por vez.**
+
+Preferência de ferramenta:
+
+1. **Inspeção via debugger/REPL** se o ambiente suporta. Um breakpoint vale por dez logs.
+2. **Logs direcionados** nas fronteiras que distinguem hipóteses.
+3. Nunca "logar tudo e grep".
+
+**Tagueie cada debug log** com um prefixo único, ex.: `[DEBUG-a4f2]`. Cleanup no final vira um único grep. Logs sem tag sobrevivem; logs tagueados morrem.
+
+**Branch de performance.** Para regressões de performance, logs estão geralmente errados. Em vez disso: estabeleça uma medição baseline (timing harness, `performance.now()`, profiler, query plan), depois faça bisection. Meça primeiro, conserte depois.
+
+---
+
+## Fase 5 — Fix + teste de regressão
+
+Escreva o teste de regressão **antes do fix** — mas apenas se existir um **seam correto** para ele.
+
+Um seam correto é um onde o teste exercita o **padrão real do bug** como ocorre no call site. Se o único seam disponível é raso demais (teste de caller único quando o bug precisa de múltiplos callers, teste unitário que não consegue replicar a chain que disparou o bug), um teste de regressão ali dá falsa confiança.
+
+**Se nenhum seam correto existe, isso em si é o finding.** Anote. A arquitetura do codebase está impedindo o bug de ser travado. Flague para a próxima fase.
+
+Se um seam correto existe:
+
+1. Transforme a repro minimizada em um teste falhando naquele seam.
+2. Veja falhar.
+3. Aplique o fix.
+4. Veja passar.
+5. Re-rode o feedback loop da Fase 1 contra o cenário original (não-minimizado).
+
+---
+
+## Fase 6 — Cleanup + post-mortem
+
+Obrigatório antes de declarar concluído:
+
+- [ ] Repro original não reproduz mais (re-rode o loop da Fase 1)
+- [ ] Teste de regressão passa (ou ausência de seam está documentada)
+- [ ] Toda instrumentação `[DEBUG-...]` removida (`grep` no prefixo)
+- [ ] Protótipos descartáveis deletados (ou movidos para local claramente marcado como debug)
+- [ ] A hipótese que se mostrou correta está declarada no commit/PR message — para que o próximo debugger aprenda
+
+**Então pergunte: o que teria prevenido este bug?** Se a resposta envolve mudança arquitetural (sem bom seam de teste, callers emaranhados, acoplamento escondido) encaminhe para a skill de melhoria de arquitetura com os specifics. Faça a recomendação **depois** do fix estar pronto, não antes — você tem mais informação agora do que quando começou.

--- a/plugins/bug-diagnostics/plugin.json
+++ b/plugins/bug-diagnostics/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "bug-diagnostics",
+  "version": "2.0.0",
+  "description": "Loop de diagnóstico para bugs difíceis e regressões de performance. Feedback loop → reprodução → hipóteses → instrumentação → fix + teste → cleanup. Invoca quando o usuário diz 'diagnosticar'/'debugar isso', ou relata algo quebrado/lento/falhando.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "repository": "https://github.com/Andersonlimahw/lemon-ai-hub",
+  "license": "MIT",
+  "credits": {
+    "based_on": "diagnosing-bugs by Matt Pocock",
+    "source": "https://github.com/mattpocock/skills/tree/main/skills/engineering/diagnosing-bugs"
+  },
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "bug-diagnostics",
+    "debugging",
+    "diagnostics",
+    "bugs",
+    "performance-regression",
+    "feedback-loop",
+    "bisection",
+    "root-cause-analysis",
+    "reproduction",
+    "hypothesis-driven",
+    "instrumentation",
+    "determinism",
+    "regression-test"
+  ]
+}

--- a/plugins/doc-driven-grilling/ADR-FORMAT.md
+++ b/plugins/doc-driven-grilling/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/plugins/doc-driven-grilling/CONTEXT-FORMAT.md
+++ b/plugins/doc-driven-grilling/CONTEXT-FORMAT.md
@@ -1,0 +1,77 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A concise description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**
+- An **Invoice** belongs to exactly one **Customer**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/plugins/doc-driven-grilling/SKILL.md
+++ b/plugins/doc-driven-grilling/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: doc-driven-grilling
+description: Interrogatório implacável para planos e designs que cria documentação (CONTEXT.md/glossário, ADRs) durante o processo, enquanto grilla. Combina grilling de decisão com domain-modeling — desafia a linguagem vaga contra o glossário existente, stress-testa cenários concretos, e captura termos e decisões inline conforme cristalizam. Use when user wants to stress-test a plan against their project's language and documented decisions, mentions "grill me", "grilling", or needs to sharpen terminology while deciding.
+disable-model-invocation: true
+---
+
+# Doc-Driven Grilling
+
+Interrogatório implacável que cria documentação enquanto grilla. Cada termo resolvido vai para o glossário; cada decisão irreversível vira ADR — capturados no momento, não em lote.
+
+Integração: `/grilling` (interrogatório de decisão) + `/domain-modeling` (modelagem de domínio e glossário).
+
+---
+
+## O fluxo
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+---
+
+## Domain awareness
+
+During codebase exploration, also look for existing documentation.
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md` exists, create one when the first term is resolved. If no `docs/adr/` exists, create it when the first ADR is needed.
+
+---
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+---
+
+## Integration: /grilling + /domain-modeling
+
+This skill unifies two workflows:
+
+- **`/grilling`** — relentless one-question-at-a-time interview that walks the decision tree, resolving dependencies one-by-one. Each question comes with a recommended answer.
+- **`/domain-modeling`** — canonical glossary (CONTEXT.md), ADRs, context maps, and relationship modeling. Terms are captured the moment they're resolved, not batched.
+
+The differentiator: documentation is a **byproduct** of grilling, not a separate phase. Every ambiguity surfaced becomes a glossary entry; every irreversible trade-off becomes an ADR. The session leaves behind a documented domain model even if the plan changes.
+
+---
+
+## Credits
+
+Based on **grill-with-docs** by Matt Pocock (https://github.com/mattpocock/skills). Adapted and extended for the lemon-ai-hub plugin ecosystem.

--- a/plugins/doc-driven-grilling/plugin.json
+++ b/plugins/doc-driven-grilling/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "doc-driven-grilling",
+  "version": "2.0.0",
+  "description": "Interrogatório implacável para planos e designs que cria documentação (ADRs, glossário/CONTEXT.md) durante o processo, enquanto grilla. Integra grilling de decisão com domain-modeling: desafia linguagem vaga contra o glossário existente, stress-testa cenários concretos, e captura termos e decisões inline conforme cristalizam. Diferencial: cria docs enquanto grilla — cada termo resolvido vai para o glossário, cada decisão irreversível vira ADR.",
+  "author": {
+    "name": "Matt Pocock",
+    "url": "https://github.com/mattpocock/skills"
+  },
+  "contributors": [
+    {
+      "name": "Anderson Lima",
+      "url": "https://andersonlimahw.github.io"
+    }
+  ],
+  "license": "MIT",
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "documentation",
+    "grilling",
+    "ADR",
+    "domain-modeling",
+    "glossary",
+    "design-docs",
+    "decision-records",
+    "context-modeling"
+  ]
+}

--- a/plugins/session-handoff/SKILL.md
+++ b/plugins/session-handoff/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: session-handoff
+description: Compacta a conversa atual em um documento de handoff para outro agent continuar o trabalho. Preserva o contexto sem duplicar artefatos.
+argument-hint: "Para que será usada a próxima sessão?"
+disable-model-invocation: true
+---
+
+# session-handoff
+
+Escreva um documento de handoff resumindo a conversa atual para que um agent novo possa continuar o trabalho. Salve no diretório temporário do sistema operacional do usuário — não no workspace atual.
+
+## Diretrizes
+
+### Evite duplicar artefatos
+
+Não duplique conteúdo já capturado em outros artefatos (specs, planos, ADRs, issues, commits, diffs). Faça referência a eles por caminho ou URL.
+
+Exemplo: em vez de colar o conteúdo de um plano, escreva:
+
+```
+- Plano de implementação: docs/plans/auth-refactor-plan.md
+- ADR aprovado: docs/adr/0007-session-storage.md
+- Issue de origem: #142 (https://github.com/org/repo/issues/142)
+- Diff em andamento: ver `git diff` no branch `feat/auth`
+```
+
+### Remova dados sensíveis
+
+Redija qualquer informação sensível antes de escrever o documento:
+
+- **API keys e tokens** — substitua por `[REDACTED: tipo]`, ex.: `[REDACTED: stripe_key]`
+- **Senhas e segredos** — nunca os inclua; referencie o cofre/variável de ambiente, ex.: `SECRET_DB_URL (via .env / vault)`
+- **PII (dados pessoais)** — emails, CPFs, telefones, nomes de usuários reais, endereços. Use marcadores como `[REDACTED: email usuário]`
+- **URLs internas/privadas** — mantenha apenas se estritamente necessário para continuidade
+
+### Seção de skills sugeridas
+
+Inclua uma seção "Skills sugeridas" no documento, recomendando skills que o agent deveria invocar na próxima sessão.
+
+### Argumentos do usuário
+
+Se o usuário passou argumentos, trate-os como a descrição do foco da próxima sessão e adapte o documento de handoff de acordo.
+
+## Estrutura do documento de handoff
+
+Use o modelo abaixo como ponto de partida, adaptando conforme o contexto:
+
+```markdown
+# Handoff — <título curto da tarefa>
+
+**Data:** <YYYY-MM-DD>
+**Foco da próxima sessão:** <argumento do usuário, se houver>
+
+## Objetivo
+<1-3 frases descrevendo o que estava sendo feito>
+
+## Progresso atual
+- <bullets do que já foi concluído>
+
+## Pendências
+- <bullets do que ainda falta fazer>
+
+## Decisões importantes
+- <decisões tomadas e por quê>
+
+## Artefatos de referência
+- Specs/planos/ADRs: <caminhos ou URLs>
+- Issues/PRs: <links>
+- Branch/diff: <branch e estado>
+
+## Armadilhas e contexto não-óbvio
+- <gotchas, dependências implícitas, comandos específicos>
+
+## Skills sugeridas
+- <skill-name> — <motivo>
+- <skill-name> — <motivo>
+
+## Próximos passos sugeridos
+1. <passo imediato>
+2. <passo seguinte>
+```
+
+## Onde salvar
+
+Salve o documento no diretório temporário do SO:
+
+- **macOS/Linux:** `$TMPDIR` (geralmente `/var/folders/.../T/`) ou `/tmp/`
+- **Windows:** `%TEMP%`
+
+Nome sugerido: `handoff-<timestamp>-<slug>.md`, ex.: `handoff-20260715-auth-refactor.md`.
+
+Informe ao usuário o caminho completo do arquivo salvo.

--- a/plugins/session-handoff/plugin.json
+++ b/plugins/session-handoff/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "session-handoff",
+  "version": "2.0.0",
+  "description": "Compacta a conversa atual em um documento de handoff para outro agent continuar o trabalho. Preserva o contexto sem duplicar artefatos.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "contributors": [
+    {
+      "name": "Matt Pocock",
+      "url": "https://github.com/mattpocock/skills"
+    }
+  ],
+  "license": "MIT",
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "session-handoff",
+    "handoff",
+    "context-preservation",
+    "session-continuation",
+    "agent-handover",
+    "context-transfer"
+  ],
+  "credits": "Based on handoff by Matt Pocock (https://github.com/mattpocock/skills)"
+}

--- a/plugins/skill-authoring/GLOSSARY.md
+++ b/plugins/skill-authoring/GLOSSARY.md
@@ -1,0 +1,163 @@
+# Glossary — Skill Authoring
+
+The domain model for what makes a skill great. A skill exists to wrangle determinism out of a stochastic system; the root virtue is **Predictability**, and every term below is a lever on it. This is the disclosed reference for [`skill-authoring`](SKILL.md).
+
+The terms are grouped by axis: **Invocation** (how a skill is reached), **Information Hierarchy** (how its content is arranged), **Steering** (how the agent\'s runtime behaviour is shaped), and **Pruning** (how it is kept lean). Each **failure mode** lives beside the lever that cures it, tagged _failure mode_.
+
+**Bold terms** in any definition are themselves defined in this glossary; find them by their heading.
+
+> **Credits**: Adapted from the [writing-great-skills GLOSSARY](https://github.com/mattpocock/skills/blob/main/skills/productivity/writing-great-skills/GLOSSARY.md) by Matt Pocock.
+
+## Predictability
+
+The degree to which a skill makes the agent behave the same _way_ on every run — the same process, not the same output (a brainstorming skill should _predictably_ diverge; its tokens vary, its behaviour doesn\'t). The root virtue every other term serves — cost and maintainability are symptoms of it, not rivals.
+
+_Avoid_: consistency, reliability, robustness, output-determinism
+
+## Invocation
+
+How a skill is reached — and the two loads you pay for the choice.
+
+### Model-Invoked
+
+A skill that keeps its **description** field, so the agent can see it and fire it autonomously — and the human can still type its name, so model-invocation always _includes_ user reach. There is no model-only state: a description only ever _adds_ agent discovery, never removes the human\'s. Pays a permanent **context load** on every turn in exchange for that discoverability. Reachable by other skills, because the description that makes it agent-discoverable makes it invocable. A model-invoked skill whose content is all **reference** is also one home for shared reference: another skill can invoke it, so reference needed by several skills lives in one place. Pick model-invocation only when the agent must reach the skill on its own; if it never fires except by hand, drop the description and pay no context load.
+
+_Avoid_: ability, tool, capability
+
+### User-Invoked
+
+A skill with its **description** stripped — invisible to the agent and reachable only by the human typing its name (user-_only_, where **model-invoked** is user-_and-agent_). Trades agent-discoverability for zero **context load**. Because it has no description, nothing but the human can reach it: no other skill can fire it.
+
+_Avoid_: procedure, workflow, command
+
+### Description
+
+The skill\'s machine-readable trigger, and the one **context pointer** a **model-invoked** skill is forced to keep loaded at all times. Its mere presence _is_ the invocation axis: keep it and the skill is model-invoked (and reachable by other skills); delete it and the skill is **user-invoked**, reachable only by the human. The source of a model-invoked skill\'s **context load**.
+
+_Avoid_: frontmatter, summary
+
+### Context Pointer
+
+A reference held in the agent\'s context that names some out-of-context material and encodes the condition for reaching it. The **description** is the top-level context pointer; a link to **disclosed reference** is another. Each pointer costs **context load** proportional to its size, so pointers should be compact and trigger-dense.
+
+### Context Load
+
+The permanent token cost a **model-invoked** skill pays every turn, because its **description** (a **context pointer**) must sit in the window for the agent to discover and fire it. The budget every pruning decision protects: if a description doesn\'t earn its context load, the skill should be **user-invoked**.
+
+### Cognitive Load
+
+The cost a **user-invoked** skill pays: the human must remember the skill exists and when to reach for it, because nothing else indexes it. The counterpart to **context load** — you pay one or the other. Cured at scale by a **router skill**.
+
+### Router Skill
+
+A **user-invoked** skill that names other user-invoked skills and when to reach for each, acting as a human-facing index. Cures the **cognitive load** that piles up when user-invoked skills multiply past what one person can remember.
+
+### Leading Word
+
+The compact term that anchors a skill\'s invocation and execution — the single word you would actually type to reach or summarise the skill. Does triple duty: names the skill, seeds the **description**\'s trigger phrasing, and concentrates what the skill _is_ in the fewest tokens. A weak leading word that the model already obeys is a **no-op**; a strong one (_relentless_ over _be thorough_) shifts behaviour without changing technique.
+
+## Information Hierarchy
+
+How a skill\'s content is arranged — the ladder ranked by how immediately the agent needs each piece.
+
+### Steps
+
+Ordered actions in `SKILL.md`, the primary tier of the **information hierarchy**. Each step ends on a **completion criterion**. Use steps when _sequence_ matters: the order of actions is itself the instruction.
+
+### Reference
+
+Material the agent consults as needed, not a sequence. Can sit in-skill (secondary tier) or be **disclosed** behind a **context pointer** (third tier). Use reference when the agent dips in on demand rather than executing top-to-bottom.
+
+### Completion Criterion
+
+The condition that tells the agent a **step** is done. The defence against **premature completion**. Must be _checkable_ (the agent can tell done from not-done) and, where it matters, _exhaustive_ ("every modified model accounted for"). A fuzzy criterion is the necessary condition for rushing; a sharp one resists the pull no matter how many later steps are visible.
+
+### Legwork
+
+The digging the agent does _within_ a step or across **reference** to actually do the work. Driven by a demanding **completion criterion**: "every rule applied" binds flat reference just as "every step done" binds a sequence. Thin legwork is one failure mode; **premature completion** is another — a step can run to full completion with thin legwork, or quit early with thorough intent.
+
+### Information Hierarchy
+
+The ladder ranking content by how immediately the agent needs it:
+
+- **Steps** — in-file, primary
+- **Reference**, in-file — secondary
+- **Reference**, disclosed — behind a **context pointer**
+
+Move material _down_ the ladder until each tier carries only what its rank demands.
+
+## Granularity
+
+How finely you divide skills — and each cut spends one of the two loads.
+
+### Granularity
+
+How finely you divide skills. Each split spends either **context load** (if the split stays model-invoked) or **cognitive load** (if it becomes user-invoked), so split only when the cut earns it. Two cuts: **by branch** and **by sequence**.
+
+### Branch
+
+A distinct trigger path within a skill. One **branch** per meaningfully different way the skill fires. Splitting by branch lowers the parent\'s **context load** when a branch grows its own **leading word** and trigger phrasing.
+
+### By Branch
+
+A granularity cut: split a skill when one **branch** grows distinct enough to deserve its own **leading word** and **description**. Moves that branch\'s triggers out of the parent\'s description, lowering the parent\'s **context load** — but adds **cognitive load** if the split becomes user-invoked.
+
+### By Sequence
+
+A granularity cut: split an ordered skill when later **steps** only matter after earlier ones finish, and the agent rushes to completion. Hiding post-completion steps behind a real context boundary (a user-invoked hand-off or a subagent dispatch) cures **premature completion**. An inline model-invoked call leaves the later steps in context and clears nothing — the split must cross a real boundary to work.
+
+## Steering
+
+How a skill shapes the agent\'s runtime behaviour beyond the sequence of steps.
+
+### Steering
+
+The discipline of shaping runtime behaviour. Two core moves: keep a **single source of truth**, and prefer **positive** phrasing over **negation**.
+
+### Single Source of Truth
+
+One authoritative place per meaning, so changing behaviour is a one-place edit. The cure for **duplication**. When two locations say the same thing, one is duplication.
+
+### Positive
+
+Steering by naming the target behaviour so the banned one is never spoken. The counterpart to **negation**: _don\'t think of an elephant_ makes the elephant more available, not less. Keep a prohibition only as a hard guardrail you can\'t phrase positively, and even then pair it with what to do instead.
+
+### Negation
+
+_Failure mode._ Steering by prohibition — _don\'t think of an elephant_ — which names the banned thing and makes it more available, not less. The cure is the **positive**: state the target behaviour so the banned one is never spoken.
+
+## Pruning
+
+How a skill is kept lean — every line costs tokens and maintenance.
+
+### Pruning
+
+The discipline of cutting lines that don\'t earn their place. Each line must justify its token and maintenance cost or leave. The four pressures to cut against are the **failure modes**: premature completion, duplication, sediment, sprawl, no-op, negation.
+
+### Relevance
+
+The property of a line still mattering to the skill\'s current behaviour. Lost slowly to **sediment** — stale layers that settle because adding feels safe and removing feels risky.
+
+## Failure Modes
+
+The named anti-patterns. Each lives beside the lever that cures it.
+
+### Premature Completion
+
+_Failure mode._ Ending the current **step** before it is genuinely done, because the agent\'s attention slips to _being done_ rather than to the work. A tug-of-war between visible post-completion steps (the pull forward) and the **completion criterion**\'s clarity (the resistance). Defence, in order: sharpen the criterion first (cheap, local); only if it is irreducibly fuzzy _and_ you observe the rush, hide the later steps by splitting **by sequence** across a real context boundary.
+
+### Duplication
+
+_Failure mode._ The same meaning in more than one place. Costs maintenance and tokens, and inflates a meaning\'s prominence on the **information hierarchy** past its real rank. The cure is the **single source of truth**.
+
+### Sediment
+
+_Failure mode._ Layers of old content that settle in a skill and are never cleared, because adding feels safe and removing feels risky — so stale and irrelevant lines accumulate. The default fate of any skill without a **pruning** discipline; the slow erosion of **relevance**, as opposed to **duplication**\'s repeated meaning.
+
+### Sprawl
+
+_Failure mode._ A skill simply too long, even when every line is live and unique. Hurts readability and maintainability and wastes tokens. The cure is the **information hierarchy**: disclose **reference** behind **context pointers**, and split **by branch** or **by sequence** so each path carries only what it needs.
+
+### No-Op
+
+_Failure mode._ A line the model already obeys by default, so you pay load to say nothing. The test: does it change behaviour versus the default? A weak **leading word** (_be thorough_ when the agent is already thorough-ish) is a no-op; the fix is a stronger word (_relentless_), not a different technique.

--- a/plugins/skill-authoring/SKILL.md
+++ b/plugins/skill-authoring/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: skill-authoring
+description: Reference for creating and editing skills well — the vocabulary and principles that make a skill predictable. Covers invocation, information hierarchy, granularity, steering, pruning, and failure modes.
+disable-model-invocation: true
+---
+
+# Skill Authoring
+
+A skill exists to wrangle determinism out of a stochastic system. **Predictability** — the agent taking the same _process_ every run, not producing the same output — is the root virtue; every lever below serves it.
+
+**Bold terms** are defined in [`GLOSSARY.md`](GLOSSARY.md); look them up there for the full meaning.
+
+> **Credits**: Based on [writing-great-skills](https://github.com/mattpocock/skills/blob/main/skills/productivity/writing-great-skills/SKILL.md) by Matt Pocock (https://github.com/mattpocock/skills). Adapted for the Lemon AI Hub plugin ecosystem.
+
+## Invocation
+
+Two choices, trading different costs:
+
+- A **model-invoked** skill keeps a **description**, so the agent can fire it autonomously _and_ other skills can reach it (you can still type its name too). It contributes to **context load** — the description sits in the window every turn. Mechanics: omit `disable-model-invocation`, and write a model-facing description with rich trigger phrasing ("Use when the user wants…, mentions…").
+- A **user-invoked** skill strips the description from the agent\'s reach: only you, typing its name, can invoke it — and no other skill can. Zero context load, but it spends **cognitive load**: _you_ are the index that must remember it exists. Mechanics: set `disable-model-invocation: true`; the `description` becomes human-facing — a one-line summary, trigger lists stripped.
+
+Pick model-invocation only when the agent must reach the skill on its own, or another skill must. If it only ever fires by hand, make it user-invoked and pay no context load.
+
+When user-invoked skills multiply past what you can remember, that piled-up cognitive load is cured by a **router skill**: one user-invoked skill that names the others and when to reach for each.
+
+## Writing the description
+
+A model-invoked **description** does two jobs — state what the skill is, and list the **branches** that should trigger it. Every word increases **context load**, so a description earns even harder pruning than the body:
+
+- **Front-load the skill\'s leading word** — the description is where it does its invocation work.
+- **One trigger per branch.** Synonyms that rename a single branch are **duplication** — "build features using TDD … asks for test-first development" is one branch written twice. Collapse them; keep only genuinely distinct branches.
+- **Cut identity that\'s already in the body.** Keep the description to triggers, plus any "when another skill needs…" reach clause.
+
+## Information hierarchy
+
+A skill is built from two content types — **steps** and **reference** — that mix freely: a skill can be all steps, all reference, or both. The core decision is which to use and where each sits on the **information hierarchy**, a ladder ranked by how immediately the agent needs the material:
+
+1. **In-skill step** — an ordered action in `SKILL.md`, the primary tier: what the agent does, in order. Each step ends on a **completion criterion**, the condition that tells the agent the work is done. Make it _checkable_ (can the agent tell done from not-done?) and, where it matters, _exhaustive_ ("every modified model accounted for").
+2. **In-skill reference** — material the agent consults as needed, secondary to steps. Lives in the same file but is not a sequence; the agent dips in when a step demands it.
+3. **Disclosed reference** — pulled out of `SKILL.md` behind a **context pointer** (a link or named callout). The agent only loads it when a step or branch needs it, keeping the top tier lean.
+
+Move material _down_ the ladder (from in-skill step, to in-skill reference, to disclosed) until each tier carries only what its rank demands. The test for "is this a step or reference?" is _sequence_: if order matters, it\'s a step; if the agent consults it on demand, it\'s reference.
+
+### Completion criteria drive legwork
+
+A demanding completion criterion drives thorough **legwork** — the digging the agent does within the work — whether the skill has steps or not, since "every rule applied" binds flat reference just as "every step done" binds a sequence.
+
+## Leading words
+
+A **leading word** is the compact term that anchors a skill\'s invocation and its execution — the single word you would actually type. It does triple duty: it names the skill (so you can reach it), seeds the description\'s trigger phrasing, and concentrates what the skill _is_ in the fewest tokens.
+
+- A weak leading word (_be thorough_ when the agent is already thorough-ish) is a **no-op** — it changes no behaviour.
+- A strong leading word (_relentless_) shifts behaviour without changing technique.
+- The leading word belongs at the front of the description: that is where invocation happens.
+
+## Granularity
+
+**Granularity** is how finely you divide skills, and each cut spends one of the two loads, so split only when the cut earns it. Two cuts:
+
+- **By branch** — split when one **branch** of a skill grows distinct enough to deserve its own leading word and description. Lowers the **context load** of the parent (the branch\'s triggers move out of the parent\'s description) but adds cognitive load if the split becomes user-invoked.
+- **By sequence** — split an ordered skill when later steps only matter after earlier ones finish, and the agent rushes to completion. Hiding post-completion steps behind a real context boundary (a user-invoked hand-off or a subagent dispatch) cures **premature completion**; an inline model-invoked call leaves the later steps in context and clears nothing.
+
+## Steering
+
+**Steering** is how a skill shapes the agent\'s runtime behaviour beyond the sequence of steps. Two disciplines:
+
+- Keep each meaning in a **single source of truth**: one authoritative place, so changing the behaviour is a one-place edit.
+- Prefer **positive** steering over **negation**. _Don\'t think of an elephant_ names the elephant and makes it more available, not less. State the target behaviour so the banned one is never spoken; keep a prohibition only as a hard guardrail you can\'t phrase positively, and even then pair it with what to do instead.
+
+## Pruning
+
+Pruning is the discipline that keeps a skill lean. Every line costs tokens and maintenance, so each must earn its place. The four pressures to cut against are the **failure modes** below.
+
+Keep the **single source of truth**: one authoritative place per meaning. When two locations say the same thing, one is **duplication**.
+
+## Failure modes
+
+Use these to diagnose issues the user may be having with the skill.
+
+- **Premature completion** — ending a step before it\'s genuinely done, attention slipping to _being done_. Defence, in order: sharpen the completion criterion first (cheap, local); only if it is irreducibly fuzzy _and_ you observe the rush, hide the post-completion steps by splitting (the sequence cut).
+- **Duplication** — the same meaning in more than one place. Costs maintenance and tokens, and inflates a meaning\'s prominence on the ladder past its real rank.
+- **Sediment** — stale layers that settle because adding feels safe and removing feels risky. The default fate of any skill without a pruning discipline.
+- **Sprawl** — a skill simply too long, even when every line is live and unique. Hurts readability and maintainability and wastes tokens. The cure is the ladder: disclose **reference** behind pointers, and split by **branch** or sequence so each path carries only what it needs.
+- **No-op** — a line the model already obeys by default, so you pay load to say nothing. The test: does it change behaviour versus the default? A weak leading word (_be thorough_ when the agent is already thorough-ish) is a no-op; the fix is a stronger word (_relentless_), not a different technique.
+- **Negation** — steering by prohibition backfires: _don\'t think of an elephant_ names the elephant and makes it more available, not less. Prompt the **positive** — state the target behaviour so the banned one is never spoken; keep a prohibition only as a hard guardrail you can\'t phrase positively, and even then pair it with what to do instead.
+
+## Completion criteria for this skill
+
+When you finish editing or creating a skill, verify:
+
+- Every **step** ends on a checkable **completion criterion**.
+- No meaning lives in more than one place (**single source of truth**).
+- The description, if present, is pruned to triggers plus reach clauses — no identity that the body already carries.
+- The invocation choice (model- vs user-invoked) matches how the skill is actually reached.
+- Each **leading word** is strong enough to change behaviour versus the default.
+- No line is a **no-op** or **negation** that a positive phrasing could replace.

--- a/plugins/skill-authoring/plugin.json
+++ b/plugins/skill-authoring/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "skill-authoring",
+  "version": "2.0.0",
+  "description": "Reference for creating and editing skills well \u2014 the vocabulary and principles that make a skill predictable. Covers invocation, information hierarchy, granularity, steering, pruning, and failure modes.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "license": "MIT",
+  "credits": {
+    "based_on": "writing-great-skills",
+    "original_author": "Matt Pocock",
+    "source": "https://github.com/mattpocock/skills"
+  },
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "skill-authoring",
+    "skill-creation",
+    "predictability",
+    "invocation",
+    "determinism",
+    "context-load",
+    "information-hierarchy",
+    "granularity",
+    "pruning",
+    "failure-modes",
+    "leading-words",
+    "matt-pocock"
+  ]
+}

--- a/plugins/task-interrogator/SKILL.md
+++ b/plugins/task-interrogator/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: task-interrogator
+description: Interrogatório implacável para planos e designs. Estressa planos antes de implementar. Baseado em grill-me/grilling de Matt Pocock.
+disable-model-invocation: true
+---
+
+# Task Interrogator
+
+Um interrogatório implacável para afiar um plano, design ou decisão antes de implementar.
+
+> Baseado em grill-me e grilling por Matt Pocock (https://github.com/mattpocock/skills)
+
+## Quando usar
+
+- Antes de começar uma implementação grande ou arriscada.
+- Quando o usuário quer estressar um plano, design, ideia ou decisão.
+- Gatilhos naturais: "interroga", "grilla", "stressa esse plano", "me entrevista sobre", "vale a pena fazer isso?", "o que pode dar errado?".
+
+## O método
+
+Entreviste o usuário de forma implacável sobre cada aspecto do plano até chegarem a um entendimento compartilhado.
+
+1. **Uma pergunta por vez.** Caminhe por cada ramo da árvore de decisões, resolvendo as dependências entre decisões uma a uma. Para cada pergunta, forneça sua resposta recomendada.
+2. **Espere o feedback de cada pergunta antes de continuar.** Fazer várias perguntas de uma vez é desorientador — o usuário se afoga em vez de pensar.
+3. **Fatos, você busca. Decisões, são do usuário.** Se um *fato* pode ser encontrado explorando o ambiente (sistema de arquivos, ferramentas, código, docs), procure em vez de perguntar. As *decisões*, no entanto, são do usuário — coloque cada uma diante dele e espere a resposta.
+4. **Não aja até o sinal verde.** Não comece a implementar nada até que o usuário confirme que chegaram a um entendimento compartilhado.
+
+## Como conduzir
+
+- Comece pelo objetivo final e trabalhe de trás para frente, OU pela decisão mais foundational e siga as dependências.
+- Priorize decisões que desbloqueiam (ou invalidam) outras — resolver elas primeiro evita retrabalho.
+- Quando o usuário hesitar, ofereça 2-3 opções concretas com trade-offs, não uma pergunta aberta infinita.
+- Para cada decisão, formule: *a pergunta* + *sua recomendação* + *o porquê* + *o que muda se disser não*.
+- Detecte premissas escondidas e traga-as à superfície: "você está assumindo X — isso é verdade?".
+- Acompanhe decisões resolvidas vs. pendentes. Releve-as quando pertinente.
+
+## Anti-padrões (NÃO faça)
+
+- Fazer N perguntas de uma vez.
+- Aceitar a primeira resposta superficial — cave mais fundo quando a justificativa for fraca.
+- Perguntar o que pode ser descoberto lendo o código.
+- Tomar a decisão pelo usuário, mesmo quando óbvia — coloque-a explicitamente.
+- Mudar de assunto antes de fechar o ramo atual.
+- Sair do modo interrogatório para implementar sem confirmação explícita.
+
+## Encerramento
+
+Quando todos os ramos da árvore estiverem resolvidos:
+
+1. Resuma as decisões tomadas num checklist numerado.
+2. Liste as premissas que ainda precisam ser validadas (se houver).
+3. Pergunte: "Estamos alinhados? Posso seguir para implementação?".
+4. Só após "sim" explícito, saia do modo interrogatório.

--- a/plugins/task-interrogator/plugin.json
+++ b/plugins/task-interrogator/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "task-interrogator",
+  "displayName": "Task Interrogator",
+  "version": "2.0.0",
+  "description": "Interrogatório implacável para planos e designs. Estressa planos antes de implementar, caminhando pela árvore de decisões uma pergunta por vez. Baseado em grill-me/grilling de Matt Pocock. Use when the user wants to stress-test a plan, design, or decision before implementation, or uses any 'grill'/'interrogate' trigger phrases.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "homepage": "https://github.com/mattpocock/skills",
+  "repository": "https://github.com/mattpocock/skills",
+  "license": "MIT",
+  "credits": "Based on grill-me and grilling by Matt Pocock (https://github.com/mattpocock/skills)",
+  "category": "productivity",
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "task-interrogator",
+    "interrogation",
+    "grilling",
+    "stress-test",
+    "plan-validation",
+    "design-review",
+    "decision-tree"
+  ],
+  "tags": [
+    "planning",
+    "design",
+    "validation",
+    "productivity"
+  ],
+  "skills": "./skills/",
+  "agents": "./agents/"
+}

--- a/plugins/teaching-workspace/README.md
+++ b/plugins/teaching-workspace/README.md
@@ -1,0 +1,50 @@
+# Teaching Workspace
+
+Stateful teaching plugin — turns the current directory into a living learning workspace that persists across sessions.
+
+Based on [teach](https://github.com/mattpocock/skills/tree/master/skills/productivity/teach) by **Matt Pocock**.
+
+## What it does
+
+When invoked, the agent treats your directory as a teaching workspace and progressively builds:
+
+```
+.
+├── MISSION.md              # Why you're learning this
+├── RESOURCES.md            # High-trust sources & communities
+├── NOTES.md                # Preferences & scratchpad
+├── lessons/                # *.html — self-contained interactive lessons
+├── reference/              # *.html — cheat sheets, glossaries, syntax
+├── learning-records/       # *.md — ADR-like records of what's been learned
+└── assets/                 # Reusable components (stylesheets, widgets)
+```
+
+## Philosophy
+
+```
+knowledge  →  skills  →  wisdom
+```
+
+- **Knowledge** from curated, high-trust resources (never parametric guesses).
+- **Skills** through interactive lessons with tight feedback loops.
+- **Wisdom** by delegating to real-world communities.
+
+Lessons target the user's **zone of proximal development** — challenging just enough. Storage strength (long-term retention) is preferred over fluency (illusory mastery) via retrieval practice, spacing, and interleaving.
+
+## Install
+
+```bash
+/add-plugin teaching-workspace
+```
+
+## Usage
+
+```
+/teaching-workspace O que você gostaria de aprender?
+```
+
+The first session grounds the mission and populates `RESOURCES.md`. Subsequent sessions read the workspace state and continue from the user's zone of proximal development.
+
+## License
+
+MIT. Credit: Matt Pocock.

--- a/plugins/teaching-workspace/SKILL.md
+++ b/plugins/teaching-workspace/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: teaching-workspace
+description: Ensina habilidades ou conceitos ao usuário em workspace stateful. Missões, lições HTML, referências, registros de aprendizado.
+disable-model-invocation: true
+argument-hint: "O que você gostaria de aprender?"
+---
+
+> Based on [teach](https://github.com/mattpocock/skills/tree/master/skills/productivity/teach) by **Matt Pocock**.
+> Adapted for lemon-ai-hub with a self-contained, inlined format spec (no external format files needed).
+
+The user has asked you to teach them something. This is a **stateful** request — they intend to learn the topic over multiple sessions. Treat the current directory as a living teaching workspace whose state is captured on disk.
+
+## Teaching Workspace
+
+The state of the user's learning lives in this directory, in these files:
+
+- `MISSION.md` — The _reason_ the user is interested in the topic. Grounds all teaching. See [Mission Format](#mission-format).
+- `RESOURCES.md` — Curated list of high-trust sources used to ground teaching, acquire knowledge, and find communities. See [Resources Format](#resources-format).
+- `./reference/*.html` — Compressed learnings: cheat sheets, reference algorithms, syntax, poses, glossaries. The raw units of knowledge. Beautiful documents that print well and are designed for quick reference.
+- `./learning-records/*.md` — Learning records: the teaching equivalent of ADRs. Capture non-obvious lessons, key insights, and stated prior knowledge that steer future sessions. Used to calculate the zone of proximal development. Titled `0001-<dash-case-name>.md`, incrementing each time. See [Learning Record Format](#learning-record-format).
+- `./lessons/*.html` — **Lessons**. A lesson is a single, self-contained HTML output that teaches one tightly-scoped thing tied to the mission. The primary unit of teaching.
+- `./assets/*` — Reusable **components** shared across lessons: stylesheets, quiz widgets, simulators, diagram helpers. See [Assets](#assets).
+- `NOTES.md` — Scratchpad for user preferences and working notes.
+
+Create directories lazily — only when the first file of each kind is written.
+
+## Philosophy
+
+To learn at a deep level, the user needs three things:
+
+1. **Knowledge** — captured from high-quality, high-trust resources.
+2. **Skills** — acquired through highly-relevant interactive lessons you devise, based on the knowledge.
+3. **Wisdom** — which comes from interacting with other learners and practitioners.
+
+This is the progression **knowledge → skills → wisdom**. Before `RESOURCES.md` is well-populated, your focus is finding high-quality resources. **Never trust your parametric knowledge.**
+
+Some topics require more skills than knowledge (theoretical physics → knowledge-heavy; yoga → skills-heavy). Calibrate per topic.
+
+### Fluency vs Storage Strength
+
+Split between two types of learning:
+
+- **Fluency strength** — in-the-moment retrieval of knowledge.
+- **Storage strength** — long-term retention of knowledge.
+
+Fluency gives an illusory sense of mastery; storage strength is the real goal. Design lessons that build long-term retention through **desirable difficulty**:
+
+- **Retrieval practice** — recall from memory.
+- **Spacing** — distribute practice over time.
+- **Interleaving** — mix up different but related topics (skills practice only).
+
+## Lessons
+
+A lesson is the main thing you produce — the unit in which knowledge and skills reach the user. Each lesson is one self-contained HTML file, saved to `./lessons/` and titled `0001-<dash-case-name>.html` where the number increments each time.
+
+A lesson should be **beautiful** — clean, readable typography and layout (think Tufte) — since the user will return to these later to review.
+
+Each lesson should be **short** and completable very quickly. Learners' working memory is small; stay within it. But each lesson should give the user a single tangible win they can build on. It must be directly tied to the mission and inside the user's [zone of proximal development](#zone-of-proximal-development).
+
+- If possible, open the lesson file for the user via a CLI command.
+- Link via HTML anchors to other lessons and reference documents.
+- Recommend **one primary source** for the user to read or watch — the most high-quality, high-trust resource you found.
+- Contain a reminder to ask follow-up questions to the agent. The agent is their teacher.
+
+## Assets
+
+Lessons are built from reusable **components**, stored in `./assets/`. Reuse is the default, not the exception. Before authoring a lesson, read `./assets/` and build from components already there. When a lesson needs something new and reusable, write it as a component and link to it — never inline code a future lesson would duplicate.
+
+A shared stylesheet is the first component every workspace earns: every lesson links it, so lessons look like one consistent course rather than a pile of one-offs. As the workspace grows, so should the component library.
+
+## The Mission
+
+Every lesson ties into the mission — the reason the user is interested in learning the topic. If the user is unclear about the mission, or `MISSION.md` is not populated, your first job is to question the user on _why_ they want to learn this. Failing to understand the mission means knowledge acquisition is not grounded in real-world goals; lessons feel too abstract and you cannot judge what to do next.
+
+Missions change as the user develops. This is normal — update `MISSION.md`, add a learning record to capture the change, and confirm with the user first.
+
+## Zone Of Proximal Development
+
+Each lesson, the user should always feel challenged _just enough_. If the user does not specify an exact thing to learn, figure out their zone of proximal development by:
+
+1. Reading their `learning-records/`.
+2. Figuring out the right thing to teach based on their mission.
+3. Teaching the most relevant thing that fits in their zone of proximal development.
+
+## Knowledge
+
+Lessons are designed around a skill the user will learn. The knowledge in the lesson should be only what is required to acquire that skill: teach the knowledge first, then have the user practice the skill via an interactive feedback loop.
+
+Knowledge should be gathered from trusted resources (tracked in `RESOURCES.md`). Lessons should be littered with citations — links to external resources backing up any claim — to increase trustworthiness. **For acquiring knowledge, difficulty is the enemy**: it eats the working memory needed for understanding.
+
+## Skills
+
+If knowledge is about acquisition, skills are about durability and flexibility — making knowledge stick. **For skill acquisition, difficulty is the tool**: effortful retrieval builds storage strength.
+
+Tools at your disposal:
+
+- Interactive lessons using quizzes and light in-browser tasks.
+- Lessons that guide the user through real-world steps (e.g. yoga poses).
+
+Each should be based on a **feedback loop** where the user receives feedback on performance. The loop should be as tight as possible — immediate, ideally automatic. For quizzes, each answer should be exactly the same number of words (and characters, if possible). Give no clues through formatting.
+
+## Acquiring Wisdom
+
+Wisdom comes from true real-world interaction — testing skills outside the learning environment. When the user asks a question that requires wisdom, your default posture is to answer, but ultimately delegate to a **community**.
+
+A community is a place (online or offline) where the user can test skills in the real world: a forum, subreddit, real-world class (budget permitting), or local interest group. Find high-reputation communities the user can join. If the user does not want to join a community, respect it.
+
+## Reference Documents
+
+While creating lessons, also create reference documents (`./reference/*.html`). Lessons can reference these — they track raw units of knowledge useful across lessons. Lessons are rarely revisited later; **reference documents will be**. They should be the compressed essence of a lesson, formatted for quick reference.
+
+Topics that lend themselves to reference:
+
+- Syntax and code snippets for programming.
+- Algorithms and flowcharts for processes.
+- Yoga poses and sequences for yoga.
+- Exercises and routines for fitness.
+- **Glossaries** for any topic with its own nomenclature. Once a glossary is created, adhere to it in every lesson.
+
+## NOTES.md
+
+The user will express preferences on how they want to be taught, or things to keep in mind. Record those here, so you can refer back when designing lessons or working with the user.
+
+---
+
+## Mission Format
+
+```md
+# Mission: {Topic}
+
+## Why
+{1-3 sentences. The concrete real-world goal the user is chasing. What changes in their life or work when they have this skill? Avoid abstract framings like "to understand X" — push for the underlying outcome.}
+
+## Success looks like
+- {A specific, observable thing the user will be able to do}
+- {Another specific thing}
+
+## Constraints
+- {Time, budget, prior commitments, learning preferences, anything that bounds the approach}
+
+## Out of scope
+- {Adjacent topics the user explicitly does not want to chase right now — protects the zone of proximal development}
+```
+
+**Rules:** Keep it concrete and outcome-driven. Abstract missions produce abstract lessons. Revisit and update as understanding deepens.
+
+## Resources Format
+
+`RESOURCES.md` is the curated set of trusted sources for this topic. Knowledge for lessons should be drawn from here, not from parametric guesses. Wisdom comes from the communities listed here.
+
+```md
+# Resources
+
+## Primary sources
+- [{Title}]({url}) — {1 sentence: why this is high-trust and what it covers}
+
+## Communities
+- [{Name}]({url}) — {1 sentence: who gathers here and what kind of wisdom the user can test}
+```
+
+**Rules:** Prefer fewer high-trust sources over many mediocre ones. Cite the reason a source is trusted. Remove sources that prove unreliable. Communities are optional but encouraged for the wisdom stage.
+
+## Learning Record Format
+
+Learning records live in `./learning-records/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc. Create the directory lazily — only when the first record is written.
+
+```md
+# {Short title of what was learned or established}
+
+{1-3 sentences: what was learned (or what prior knowledge was established), and why it matters for future sessions.}
+```
+
+That is the whole format. A learning record can be a single paragraph. The value is recording _that_ this is now known and _why_ it changes what to teach next — not in filling out sections.
+
+**When to write a learning record:**
+
+- A non-obvious insight that will steer future lessons.
+- Stated prior knowledge that should not be re-taught.
+- A correction to an earlier misunderstanding.
+- A mission change.
+
+**What does _not_ qualify:** routine progress, lesson completion, or anything already captured in a lesson or reference doc.
+
+**Numbering:** scan `./learning-records/` for the highest existing number and increment by one.
+
+**Supersession:** if a record is later found wrong, do not delete it — write a new record that supersedes it and reference the old one (e.g. "Supersedes 0002-..."). Leave the earlier record in place for the trail.

--- a/plugins/teaching-workspace/assets/.gitkeep
+++ b/plugins/teaching-workspace/assets/.gitkeep
@@ -1,0 +1,2 @@
+# Reusable lesson components (stylesheets, quiz widgets, simulators).
+# Created lazily by the teaching-workspace skill.

--- a/plugins/teaching-workspace/plugin.json
+++ b/plugins/teaching-workspace/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "teaching-workspace",
+  "displayName": "Teaching Workspace",
+  "version": "2.0.0",
+  "description": "Ensina habilidades ou conceitos ao usuário em workspace stateful. Missões, lições HTML, referências, registros de aprendizado. Cria roadmap personalizado com lições interativas, documentos de referência e registros de aprendizado que persistem entre sessões.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "homepage": "https://github.com/mattpocock/skills/tree/master/skills/productivity/teach",
+  "repository": "https://github.com/mattpocock/skills",
+  "license": "MIT",
+  "credits": "Based on teach by Matt Pocock (https://github.com/mattpocock/skills)",
+  "category": "education",
+  "tags": [
+    "teaching",
+    "learning",
+    "education",
+    "stateful-learning",
+    "workspace",
+    "lessons",
+    "mentorship"
+  ],
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "teaching",
+    "learning",
+    "education",
+    "skills",
+    "lessons",
+    "workspace",
+    "stateful-learning",
+    "mission-driven",
+    "zone-of-proximal-development",
+    "interactive-lessons",
+    "knowledge-transfer",
+    "spaced-repetition",
+    "learning-records"
+  ]
+}


### PR DESCRIPTION
## Summary

Adiciona 7 novos plugins ao lemon-ai-hub adaptados das skills de Matt Pocock (https://github.com/mattpocock/skills). Todos os plugins mantêm créditos originais e seguem a estrutura do projeto.

## Plugins Adicionados

| Plugin | Skill Original | Descrição |
|--------|---------------|-----------|
| `architecture-deepener` | improve-codebase-architecture | Superficia oportunidades de deepening (shallow→deep modules) |
| `bug-diagnostics` | diagnosing-bugs | Loop diagnóstico para bugs difíceis + regressões |
| `doc-driven-grilling` | grill-with-docs | Interrogatório que cria ADRs/glossário durante processo |
| `session-handoff` | handoff | Preserva contexto para handoff entre agents |
| `skill-authoring` | writing-great-skills | Referência para criar skills previsíveis |
| `task-interrogator` | grill-me/grilling | Estressa planos antes de implementar |
| `teaching-workspace` | teach | Workspace stateful para aprendizado |

## SEO & Keywords

Todos os plugins incluem keywords otimizadas para descoberta:
- interrogation, grilling, stress-test, plan-validation
- handoff, context-preservation, session-continuation
- teaching, learning, education, workspace
- skill-creation, predictability, determinism
- debugging, diagnostics, feedback-loop
- architecture, refactoring, deepening
- documentation, adr, domain-modeling

## Atribuição

Todos os plugins creditam Matt Pocock explicitamente:
- Campo `credits`/`based_on` em plugin.json
- Nota no topo de SKILL.md
- Co-Authored-By nos commits

## Estrutura

✓ Cada plugin tem diretório próprio com:
  - `SKILL.md` (frontmatter válido + corpo adaptado em PT-BR)
  - `plugin.json` (v2.0.0, keywords SEO)
  - `skills/` e `agents/` (placeholders)

✓ marketplace.json atualizado com 7 novas entradas (ordem alfabética)
✓ README.md atualizado com tabela expandida

## Commits

1. feat: add task-interrogator plugin
2. feat: add session-handoff plugin
3. feat: add teaching-workspace plugin
4. feat: add skill-authoring plugin
5. feat: add bug-diagnostics plugin
6. feat: add architecture-deepener plugin
7. feat: add doc-driven-grilling plugin
8. docs: add 7 Matt Pocock-based plugins to marketplace.json

## Testado

- ✓ JSON valid (marketplace.json + todos plugin.json)
- ✓ Frontmatter válido em todos SKILL.md
- ✓ Ordem alfabética mantida
- ✓ Keywords SEO presentes
- ✓ Créditos preservados

---

Co-Authored-By: Matt Pocock <https://github.com/mattpocock>