### PR TITLE
fix(scripts): safe pull for managed clone — back up colliding untracked files

### DIFF
--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -16,6 +16,32 @@ echo -e "${GREEN}      🍋 Lemon AI Hub Setup 🍋         ${NC}"
 echo -e "${BLUE}=======================================${NC}"
 echo ""
 
+# Pull the managed clone safely: fetch first, move any untracked file that the
+# incoming changes would overwrite into a timestamped backup dir, then pull.
+update_repo() {
+  local repo_root="$1"
+  git -C "$repo_root" fetch origin main --quiet || {
+    echo -e "${RED}WARNING: fetch failed for $repo_root${NC}" >&2
+    return 1
+  }
+  local incoming
+  incoming=$(git -C "$repo_root" diff --name-only HEAD FETCH_HEAD)
+  local backup_dir="$repo_root/.pull-backup-$(date +%s)"
+  local moved=0
+  local f
+  while IFS= read -r f; do
+    if [ -e "$repo_root/$f" ] && ! git -C "$repo_root" ls-files --error-unmatch -- "$f" >/dev/null 2>&1; then
+      mkdir -p "$backup_dir/$(dirname "$f")"
+      mv "$repo_root/$f" "$backup_dir/$f"
+      moved=1
+    fi
+  done <<< "$incoming"
+  if [ "$moved" = "1" ]; then
+    echo -e "${YELLOW}Moved conflicting untracked files to ${BLUE}$backup_dir${NC}"
+  fi
+  git -C "$repo_root" pull origin main
+}
+
 # Ensure we have the repository cloned or are inside it
 if [ -d "$PWD/plugins" ] && [ -d "$PWD/.git" ]; then
   REPO_ROOT="$PWD"
@@ -26,7 +52,7 @@ else
   if [ ! -d "$REPO_ROOT" ]; then
     git clone https://github.com/Andersonlimahw/lemon-ai-hub.git "$REPO_ROOT"
   else
-    git -C "$REPO_ROOT" pull
+    update_repo "$REPO_ROOT"
   fi
   echo ""
 fi

--- a/scripts/menu.sh
+++ b/scripts/menu.sh
@@ -30,6 +30,7 @@ update_repo() {
   local moved=0
   local f
   while IFS= read -r f; do
+    [ -z "$f" ] && continue
     if [ -e "$repo_root/$f" ] && ! git -C "$repo_root" ls-files --error-unmatch -- "$f" >/dev/null 2>&1; then
       mkdir -p "$backup_dir/$(dirname "$f")"
       mv "$repo_root/$f" "$backup_dir/$f"

--- a/scripts/setup-symlinks.sh
+++ b/scripts/setup-symlinks.sh
@@ -13,6 +13,32 @@
 
 set -euo pipefail
 
+# Pull the managed clone safely: fetch first, move any untracked file that the
+# incoming changes would overwrite into a timestamped backup dir, then pull.
+update_repo() {
+  local repo_root="$1"
+  git -C "$repo_root" fetch origin main --quiet || {
+    echo "WARNING: fetch failed for $repo_root" >&2
+    return 1
+  }
+  local incoming
+  incoming=$(git -C "$repo_root" diff --name-only HEAD FETCH_HEAD)
+  local backup_dir="$repo_root/.pull-backup-$(date +%s)"
+  local moved=0
+  local f
+  while IFS= read -r f; do
+    if [ -e "$repo_root/$f" ] && ! git -C "$repo_root" ls-files --error-unmatch -- "$f" >/dev/null 2>&1; then
+      mkdir -p "$backup_dir/$(dirname "$f")"
+      mv "$repo_root/$f" "$backup_dir/$f"
+      moved=1
+    fi
+  done <<< "$incoming"
+  if [ "$moved" = "1" ]; then
+    echo "Moved conflicting untracked files to $backup_dir"
+  fi
+  git -C "$repo_root" pull origin main
+}
+
 # Get the absolute path of the repository's plugins directory
 if [ -d "$PWD/plugins" ] && [ -d "$PWD/.git" ]; then
   # Running from within a local clone
@@ -24,7 +50,7 @@ else
   if [ ! -d "$REPO_ROOT" ]; then
     git clone https://github.com/Andersonlimahw/lemon-ai-hub.git "$REPO_ROOT"
   else
-    git -C "$REPO_ROOT" pull
+    update_repo "$REPO_ROOT"
   fi
 fi
 REPO_PLUGINS_DIR="$REPO_ROOT/plugins"

--- a/scripts/setup-symlinks.sh
+++ b/scripts/setup-symlinks.sh
@@ -27,6 +27,7 @@ update_repo() {
   local moved=0
   local f
   while IFS= read -r f; do
+    [ -z "$f" ] && continue
     if [ -e "$repo_root/$f" ] && ! git -C "$repo_root" ls-files --error-unmatch -- "$f" >/dev/null 2>&1; then
       mkdir -p "$backup_dir/$(dirname "$f")"
       mv "$repo_root/$f" "$backup_dir/$f"


### PR DESCRIPTION
## Problem

Running `bash -c "$(curl -fsSL .../scripts/menu.sh)"` fails when `~/.lemon-ai-hub` has untracked files that incoming changes would overwrite:

```
error: The following untracked working tree files would be overwritten by merge:
    plugins/hatch-pet/...
Please move or remove them before you merge.
Aborting
```

Root cause: stale untracked debris (e.g. `plugins/hatch-pet/` left by an interrupted merge) makes the bare `git -C ~/.lemon-ai-hub pull` abort.

## Fix

New `update_repo()` in `menu.sh` and `setup-symlinks.sh`:
1. `git fetch origin main`
2. Diff `HEAD..FETCH_HEAD`; for every untracked file that the incoming changes would overwrite, move it to `.pull-backup-<ts>/` (non-destructive)
3. `git pull origin main` — now succeeds

## Verification

Reproduced the exact original error in a temp clone (reset to feff32e + stray untracked `plugins/hatch-pet/`), then ran `update_repo`: stray files moved to backup, pull completed to 460faa9, working tree clean.