### PR TITLE
feat(smart-sub-agents): cross-harness worker matrix + install/sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2038,8 +2038,8 @@
     {
       "name": "smart-sub-agents",
       "source": "./plugins/smart-sub-agents",
-      "description": "Creates portable subagent routes with explicit harness, provider, model, and effort selection. Ships a verified model matrix, normalization for common aliases, and renderers for Claude Code, Codex, OpenCode, Antigravity, Gemini CLI, and lemon-code.",
-      "version": "1.0.0",
+      "description": "Creates portable subagent routes with explicit harness, provider, model, and effort selection. Ships a verified provider/model matrix, normalization for common aliases, renderers for Claude Code, Codex, OpenCode, Antigravity, Gemini CLI, and lemon-code, plus an idempotent worker-matrix installer (Claude canonical, Codex TOML, OpenCode md, Agy symlink) and a monthly/weekly sync that reconciles the catalog against live `opencode models` (discovered/stale) without inventing model IDs.",
+      "version": "1.1.0",
       "license": "MIT",
       "keywords": [
         "skill",
@@ -2049,11 +2049,15 @@
         "provider-routing",
         "model-routing",
         "effort",
+        "worker-matrix",
+        "named-workers",
         "claude-code",
         "codex",
         "opencode",
         "antigravity",
-        "gemini"
+        "gemini",
+        "model-sync",
+        "budget-contract"
       ]
     },
     {

--- a/plugins/smart-dispatch/SKILL.md
+++ b/plugins/smart-dispatch/SKILL.md
@@ -60,22 +60,43 @@ Any agent dispatched in YOLO/Bypass mode **MUST** execute the relevant validatio
 
 Always pick the **cheapest tier that passes validation**; escalate per 1.1. Tiers map per provider:
 
-| Tier | Claude | Codex subagent | Gemini |
-|------|--------|----------------|--------|
-| **budget** | Haiku 4.5 | Luna (low/medium effort) | Flash |
-| **balanced** | Sonnet 4.6 | Terra (medium/high effort) | Pro |
-| **quality** | Opus 4.8 / Fable 5 | Sol (high/xhigh effort) | Pro (max thinking) |
+| Tier | Claude worker | Codex worker | OpenCode Zen | OpenCode Go | Gemini |
+|------|---------------|--------------|--------------|-------------|--------|
+| **budget** | `haiku_worker_{low\|medium\|high}` | `luna_worker_{low…max}` | `zen_flash_*` / `zen_luna_*` | `go_luna_*` / `go_flash_*` | Flash-Lite |
+| **balanced** | `sonnet_worker_{low…xhigh}` | `terra_worker_{low…max}` | `zen_terra_*` / `zen_grok_*` | `go_grok_*` / `go_glm_*` / `go_kimi_*` | Flash |
+| **quality** | `opus_worker_{low…max}` | `sol_worker_{low…max}` | `zen_sol_*` / `zen_opus_*` | `go_pro_*` / `go_qwen_max_*` | Pro |
 
-Use the newest available OpenAI Codex aliases in this order: **Luna** for bounded mechanical work, **Terra** for implementation and integration, and **Sol** for architecture, adversarial review, or repeated validation failures. These are dispatch-only names; never add them to an application's LLM provider catalog.
+Use named workers when the harness supports custom agents. Prefer the **cheapest worker that still fits the task**. Codex: **Luna** mechanical, **Terra** implementation, **Sol** architecture/root-cause. Claude: **Haiku / Sonnet / Opus**. OpenCode: prefer **Go** lane when subscribed; else **Zen free**.
 
-| Task type | Tier | Notes |
-|-----------|------|-------|
-| Docs, comments, changelogs, summaries, translations | budget | Haiku-class is enough; never burn Opus here |
-| Test writing — mechanical / known pattern | budget | Verify with test run (0.3 mandate) |
-| Lint / typecheck / format fixes | local CLI → budget | Tier 0 rules apply first |
-| Implementation, refactor, multi-step agentic | balanced | Sonnet-class default for code |
-| Test design — integration/e2e strategy | balanced | Strategy needs reasoning; writing the cases can drop to budget |
-| Plan, architecture, root-cause, security audit, migration | quality | Opus-class; deep reasoning pays for itself |
+### Budget contract (mandatory on every dispatch)
+
+Announce before work:
+
+```text
+DISPATCH
+worker: <name>
+tier: budget|balanced|quality
+effort: low|medium|high|xhigh|max
+tokens: <range from taskRouting>
+time: <range from taskRouting>
+verify: <command>
+```
+
+Source of truth: `plugins/smart-sub-agents/references/provider-matrix.json` → `taskRouting` + `workerMatrix`.
+Refresh models: `python3 plugins/smart-sub-agents/scripts/sync_provider_matrix.py --write`
+Reinstall workers: `python3 plugins/smart-sub-agents/scripts/install_worker_matrix.py`
+
+| Task type | Tier | Default worker (Claude / Codex) | Tokens | Time |
+|-----------|------|----------------------------------|--------|------|
+| Docs, comments, changelogs, summaries, translations | budget | `haiku_worker_low` / `luna_worker_low` | 2k–8k | 1–5min |
+| Test writing — mechanical / known pattern | budget | `haiku_worker_low` / `luna_worker_low` | 3k–12k | 3–10min |
+| Lint / typecheck / format fixes | local CLI → budget | Tier 0 first, then haiku/luna | 1k–6k | 1–5min |
+| Boilerplate / scaffolding | budget | `haiku_worker_medium` / `luna_worker_medium` | 2k–10k | 2–8min |
+| Implementation, refactor | balanced | `sonnet_worker_medium` / `terra_worker_medium` | 8k–40k | 10–40min |
+| Multi-step agentic | balanced | `sonnet_worker_high` / `terra_worker_high` | 15k–60k | 15–60min |
+| Test design — integration/e2e strategy | balanced | `sonnet_worker_medium` / `terra_worker_medium` | 6k–25k | 8–25min |
+| Plan, architecture, security audit, migration | quality | `opus_worker_high` / `sol_worker_high` | 15k–80k | 15–90min |
+| Root-cause / hard debug | quality | `opus_worker_xhigh` / `sol_worker_xhigh` | 20k–100k | 20–90min |
 
 EXEC-MAP's `models: {plan, impl, mechanical}` maps 1:1 to quality/balanced/budget rows above.
 

--- a/plugins/smart-sub-agents/README.md
+++ b/plugins/smart-sub-agents/README.md
@@ -1,13 +1,78 @@
 # Smart Sub-Agents
 
-Portable provider/model/effort routing for Claude Code, Codex, OpenCode, Antigravity, Gemini CLI, and lemon-code.
+Portable provider/model/effort routing for Claude Code, Codex, OpenCode, Antigravity, Gemini CLI, and lemon-code, plus a versioned **worker matrix** that installs tiered named workers into every harness.
 
-The plugin keeps a curated, source-linked matrix in [`references/provider-matrix.json`](references/provider-matrix.json), resolves explicit routes, normalizes a small set of known aliases, and renders native or handoff artifacts without writing global configuration by default.
+The plugin keeps a curated, source-linked matrix in [`references/provider-matrix.json`](references/provider-matrix.json), resolves explicit routes, normalizes a small set of known aliases, and renders native or handoff artifacts without writing global configuration by default. It pairs with [`smart-dispatch`](../smart-dispatch/SKILL.md), which announces a `DISPATCH` budget contract and picks the cheapest worker that still fits the task.
+
+## Worker matrix (named agents)
+
+A tier x effort grid of named subagents is generated from the matrix and installed into each harness. Claude bodies are canonical; other harnesses render/symlink.
+
+| Harness | Pattern | Example | Location |
+| --- | --- | --- | --- |
+| Claude (canonical) | `{haiku\|sonnet\|opus}_worker_{effort}` | `sonnet_worker_high` | `~/.claude/agents/` |
+| Codex | `{luna\|terra\|sol}_worker_{effort}` | `luna_worker_max` | `~/.codex/agents/` |
+| OpenCode Zen (free) | `zen_{family}_worker_{effort}` | `zen_sol_worker_max` | `~/.config/opencode/agents/` |
+| OpenCode Go (subscription) | `go_{family}_worker_{effort}` | `go_luna_worker_high` | `~/.config/opencode/agents/` |
+| Agy | symlink -> Claude workers + Codex-named aliases | `opus_worker_high` -> `~/.claude/agents/...` | `~/.agy/agents/` |
+
+Every generated file carries the marker `managed-by: smart-sub-agents/worker-matrix` and the installer is idempotent: re-running it never duplicates managed workers and never deletes non-managed agents.
+
+## Setup (hub + a maintainer machine)
+
+Run from the repo root so the scripts resolve the catalog via a relative path:
 
 ```bash
-python3 scripts/validate_catalog.py
-python3 scripts/render_agents.py --harness all --profile balanced --output-dir .smart-sub-agents/generated
-python3 -m unittest discover -s tests -p 'test_*.py'
+cd "$(git rev-parse --show-toplevel)"   # lemon-ai-hub root
+
+# 1) Validate the catalog (providers, models, harnesses, workerMatrix, taskRouting)
+python3 plugins/smart-sub-agents/scripts/validate_catalog.py
+
+# 2) Unit tests
+python3 -m unittest discover -s plugins/smart-sub-agents/tests -p 'test_*.py' -v
+
+# 3) Sync live OpenCode Zen/Go models against `opencode models` (dry report)
+python3 plugins/smart-sub-agents/scripts/sync_provider_matrix.py
+
+# 4) Optional: persist discovered/stale flags + bump the `updated` date
+python3 plugins/smart-sub-agents/scripts/sync_provider_matrix.py --write
+
+# 5) Install workers into local harness dirs (~/.claude|codex|config/opencode|agy/agents)
+python3 plugins/smart-sub-agents/scripts/install_worker_matrix.py
+
+# 6) Validate the installed files (frontmatter + managed marker per harness)
+python3 plugins/smart-sub-agents/scripts/install_worker_matrix.py --validate-only
 ```
 
-See [`SKILL.md`](SKILL.md) for the routing protocol and [`references/provider-matrix.md`](references/provider-matrix.md) for the provider/harness distinction and current recommendations.
+Tip: render artifacts into the repo without touching global config first, then copy the ones you want:
+
+```bash
+python3 plugins/smart-sub-agents/scripts/render_agents.py --harness all --profile balanced --output-dir .smart-sub-agents/generated
+python3 plugins/smart-sub-agents/scripts/render_agents.py --harness opencode --provider deepseek --model deepseek-v4-flash --effort max --output-dir .smart-sub-agents/generated
+```
+
+## Sync (monthly / weekly drift)
+
+The matrix is a curated snapshot, not a live provider API. Models are added, deprecated, and gain new effort options over time. Keep it current with a three-command cadence:
+
+```bash
+# 1) Report drift: newly observed OpenCode models are marked `discovered`,
+#    models no longer live are marked `stale`. Nothing is written yet.
+python3 plugins/smart-sub-agents/scripts/sync_provider_matrix.py
+
+# 2) Promote or remove entries in references/provider-matrix.json by hand,
+#    then persist the catalog and re-run the validator so it stays green:
+python3 plugins/smart-sub-agents/scripts/sync_provider_matrix.py --write
+
+# 3) Reinstall workers so harnesses reflect the promoted matrix:
+python3 plugins/smart-sub-agents/scripts/install_worker_matrix.py
+```
+
+`discovered` models stay status `discovered` until a human moves them into `workerMatrix` / profiles. The syncer never auto-deletes and never invents a model ID the live catalog did not return. Re-validate after every matrix change.
+
+## Where to read more
+
+- [`SKILL.md`](SKILL.md) - routing protocol (`ROUTE-MAP v1`) and the install/sync commands.
+- [`references/provider-matrix.md`](references/provider-matrix.md) - recommended routes, alias corrections, and the harness-vs-provider distinction.
+- [`references/provider-matrix.json`](references/provider-matrix.json) - the verified catalog: providers, models, harnesses, `workerMatrix`, `taskRouting`, `aliases`.
+- [`plugins/smart-dispatch/SKILL.md`](../smart-dispatch/SKILL.md) - task -> tier -> worker routing table and the mandatory `DISPATCH` budget contract.

--- a/plugins/smart-sub-agents/SKILL.md
+++ b/plugins/smart-sub-agents/SKILL.md
@@ -101,6 +101,43 @@ reason: quality-first coding route with DeepSeek V4 Flash thinking mode
 
 Do not add secrets, invent provider support, or fall back after an explicit cancellation. A fallback is only a declared route for a provider outage or unavailable model and must be visible to the caller.
 
+## Worker matrix (named agents)
+
+Install the full tier × effort worker grid into local harnesses:
+
+```bash
+python3 plugins/smart-sub-agents/scripts/validate_catalog.py
+python3 plugins/smart-sub-agents/scripts/install_worker_matrix.py
+python3 plugins/smart-sub-agents/scripts/install_worker_matrix.py --validate-only
+```
+
+Naming contract:
+
+| Harness | Pattern | Example |
+| --- | --- | --- |
+| Claude (canonical) | `{haiku\|sonnet\|opus}_worker_{effort}` | `sonnet_worker_high` |
+| Codex | `{luna\|terra\|sol}_worker_{effort}` | `luna_worker_max` |
+| OpenCode Zen | `zen_{family}_worker_{effort}` | `zen_sol_worker_max` |
+| OpenCode Go | `go_{family}_worker_{effort}` | `go_luna_worker_high` |
+| Agy | symlink → Claude workers + Codex-named aliases | `opus_worker_high` → `~/.claude/agents/...` |
+
+Claude bodies are canonical. Codex gets native TOML (`model` + `model_reasoning_effort`). OpenCode gets adapted markdown (`mode/permission/model`). Agy symlinks Claude.
+
+## Sync models/providers (monthly/weekly drift)
+
+```bash
+# Dry report against live `opencode models`
+python3 plugins/smart-sub-agents/scripts/sync_provider_matrix.py
+
+# Persist discovered/stale flags + bump updated date
+python3 plugins/smart-sub-agents/scripts/sync_provider_matrix.py --write
+
+# Reinstall workers after promoting discovered models
+python3 plugins/smart-sub-agents/scripts/install_worker_matrix.py
+```
+
+Discovered models stay `status: discovered` until a human promotes them into `workerMatrix` / profiles. Never auto-delete.
+
 ## Refresh policy
 
-The matrix is a curated snapshot, not a live provider API. Check the linked official documentation before production rollout and update `updated` plus the affected source URL when a model is added, deprecated, renamed, or changes effort semantics. Run the validator and tests after every matrix change.
+The matrix is a curated snapshot, not a live provider API. Check the linked official documentation before production rollout and update `updated` plus the affected source URL when a model is added, deprecated, renamed, or changes effort semantics. Run the validator and tests after every matrix change. Prefer `sync_provider_matrix.py` for OpenCode Zen/Go drift.

--- a/plugins/smart-sub-agents/plugin.json
+++ b/plugins/smart-sub-agents/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-sub-agents",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Creates portable subagent routes with explicit harness, provider, model, and effort selection. Ships a verified model matrix, normalization for common aliases, and renderers for Claude Code, Codex, OpenCode, Antigravity, Gemini CLI, and lemon-code.",
   "author": {
     "name": "Anderson Lima",

--- a/plugins/smart-sub-agents/references/provider-matrix.json
+++ b/plugins/smart-sub-agents/references/provider-matrix.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schemaVersion": 1,
-  "updated": "2026-08-02",
+  "updated": "2026-08-16",
   "efforts": ["none", "low", "medium", "high", "xhigh", "max", "ultra"],
   "profiles": {
     "budget": {
@@ -9,7 +9,7 @@
       "routes": {
         "claude-code": {"provider": "anthropic", "model": "claude-haiku-4-5"},
         "codex": {"provider": "openai", "model": "gpt-5.6-luna"},
-        "opencode": {"provider": "openai", "model": "gpt-5.6-luna"},
+        "opencode": {"provider": "opencode", "model": "deepseek-v4-flash-free"},
         "antigravity": {"provider": "google", "model": "gemini-3.5-flash-lite"},
         "gemini-cli": {"provider": "google", "model": "gemini-3.5-flash-lite"},
         "lemon-code": {"provider": "openrouter", "model": "auto"}
@@ -20,7 +20,7 @@
       "routes": {
         "claude-code": {"provider": "anthropic", "model": "claude-sonnet-5"},
         "codex": {"provider": "openai", "model": "gpt-5.6-terra"},
-        "opencode": {"provider": "openai", "model": "gpt-5.6-terra"},
+        "opencode": {"provider": "opencode-go", "model": "gpt-5.6-luna"},
         "antigravity": {"provider": "google", "model": "gemini-3.6-flash"},
         "gemini-cli": {"provider": "google", "model": "gemini-3.6-flash"},
         "lemon-code": {"provider": "openrouter", "model": "auto"}
@@ -30,8 +30,8 @@
       "effort": "high",
       "routes": {
         "claude-code": {"provider": "anthropic", "model": "claude-opus-5"},
-        "codex": {"provider": "openai", "model": "gpt-5.6"},
-        "opencode": {"provider": "openai", "model": "gpt-5.6"},
+        "codex": {"provider": "openai", "model": "gpt-5.6-sol"},
+        "opencode": {"provider": "opencode", "model": "gpt-5.6-sol"},
         "antigravity": {"provider": "google", "model": "gemini-3.1-pro-preview"},
         "gemini-cli": {"provider": "google", "model": "gemini-3.1-pro-preview"},
         "lemon-code": {"provider": "openrouter", "model": "auto"}
@@ -41,19 +41,254 @@
       "effort": "max",
       "routes": {
         "claude-code": {"provider": "anthropic", "model": "claude-fable-5"},
-        "codex": {"provider": "openai", "model": "gpt-5.6"},
-        "opencode": {"provider": "anthropic", "model": "claude-opus-5"},
+        "codex": {"provider": "openai", "model": "gpt-5.6-sol"},
+        "opencode": {"provider": "opencode", "model": "claude-opus-5"},
         "antigravity": {"provider": "google", "model": "antigravity-agent-preview"},
         "gemini-cli": {"provider": "google", "model": "gemini-deep-research-max-preview"},
         "lemon-code": {"provider": "openrouter", "model": "auto"}
       }
     }
   },
+  "workerMatrix": {
+    "claude-code": {
+      "canonical": true,
+      "families": [
+        {
+          "id": "haiku",
+          "provider": "anthropic",
+          "model": "claude-haiku-4-5",
+          "tier": "budget",
+          "efforts": ["low", "medium", "high"],
+          "tasks": ["docs", "comments", "changelogs", "mechanical-tests", "lint-fixes", "boilerplate"]
+        },
+        {
+          "id": "sonnet",
+          "provider": "anthropic",
+          "model": "claude-sonnet-5",
+          "tier": "balanced",
+          "efforts": ["low", "medium", "high", "xhigh"],
+          "tasks": ["implementation", "refactor", "integration-tests", "multi-step-agentic"]
+        },
+        {
+          "id": "opus",
+          "provider": "anthropic",
+          "model": "claude-opus-5",
+          "tier": "quality",
+          "efforts": ["low", "medium", "high", "xhigh", "max"],
+          "tasks": ["architecture", "plans", "root-cause", "security-audit", "migration"]
+        }
+      ]
+    },
+    "codex": {
+      "canonical": false,
+      "sourceOfTruth": "claude-code",
+      "families": [
+        {
+          "id": "luna",
+          "provider": "openai",
+          "model": "gpt-5.6-luna",
+          "tier": "budget",
+          "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
+          "tasks": ["docs", "comments", "changelogs", "mechanical-tests", "lint-fixes", "boilerplate"]
+        },
+        {
+          "id": "terra",
+          "provider": "openai",
+          "model": "gpt-5.6-terra",
+          "tier": "balanced",
+          "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
+          "tasks": ["implementation", "refactor", "integration-tests", "multi-step-agentic"]
+        },
+        {
+          "id": "sol",
+          "provider": "openai",
+          "model": "gpt-5.6-sol",
+          "tier": "quality",
+          "efforts": ["none", "low", "medium", "high", "xhigh", "max"],
+          "tasks": ["architecture", "plans", "root-cause", "security-audit", "migration"]
+        }
+      ]
+    },
+    "opencode": {
+      "canonical": false,
+      "sourceOfTruth": "claude-code",
+      "lanes": {
+        "zen": {
+          "label": "OpenCode Zen free",
+          "families": [
+            {
+              "id": "zen_flash",
+              "provider": "opencode",
+              "model": "deepseek-v4-flash-free",
+              "tier": "budget",
+              "efforts": ["low", "medium", "high"],
+              "tasks": ["docs", "boilerplate", "mechanical-tests", "lint-fixes"]
+            },
+            {
+              "id": "zen_luna",
+              "provider": "opencode",
+              "model": "gpt-5.6-luna",
+              "tier": "budget",
+              "efforts": ["low", "medium", "high", "xhigh", "max"],
+              "tasks": ["docs", "bounded-impl", "mechanical-tests"]
+            },
+            {
+              "id": "zen_terra",
+              "provider": "opencode",
+              "model": "gpt-5.6-terra",
+              "tier": "balanced",
+              "efforts": ["low", "medium", "high", "xhigh", "max"],
+              "tasks": ["implementation", "refactor", "integration"]
+            },
+            {
+              "id": "zen_sol",
+              "provider": "opencode",
+              "model": "gpt-5.6-sol",
+              "tier": "quality",
+              "efforts": ["low", "medium", "high", "xhigh", "max"],
+              "tasks": ["architecture", "plans", "adversarial-review"]
+            },
+            {
+              "id": "zen_opus",
+              "provider": "opencode",
+              "model": "claude-opus-5",
+              "tier": "quality",
+              "efforts": ["low", "medium", "high", "xhigh", "max"],
+              "tasks": ["architecture", "plans", "security-audit"]
+            },
+            {
+              "id": "zen_grok",
+              "provider": "opencode",
+              "model": "grok-4.5",
+              "tier": "balanced",
+              "efforts": ["low", "medium", "high"],
+              "tasks": ["implementation", "fast-reasoning"]
+            }
+          ]
+        },
+        "go": {
+          "label": "OpenCode Go subscription",
+          "families": [
+            {
+              "id": "go_luna",
+              "provider": "opencode-go",
+              "model": "gpt-5.6-luna",
+              "tier": "budget",
+              "efforts": ["low", "medium", "high", "xhigh", "max"],
+              "tasks": ["docs", "boilerplate", "mechanical-tests"]
+            },
+            {
+              "id": "go_flash",
+              "provider": "opencode-go",
+              "model": "deepseek-v4-flash",
+              "tier": "budget",
+              "efforts": ["low", "medium", "high"],
+              "tasks": ["docs", "boilerplate", "lint-fixes"]
+            },
+            {
+              "id": "go_grok",
+              "provider": "opencode-go",
+              "model": "grok-4.5",
+              "tier": "balanced",
+              "efforts": ["low", "medium", "high"],
+              "tasks": ["implementation", "refactor"]
+            },
+            {
+              "id": "go_glm",
+              "provider": "opencode-go",
+              "model": "glm-5.2",
+              "tier": "balanced",
+              "efforts": ["low", "medium", "high"],
+              "tasks": ["implementation", "agentic"]
+            },
+            {
+              "id": "go_kimi",
+              "provider": "opencode-go",
+              "model": "kimi-k2.7-code",
+              "tier": "balanced",
+              "efforts": ["low", "medium", "high"],
+              "tasks": ["implementation", "long-context"]
+            },
+            {
+              "id": "go_pro",
+              "provider": "opencode-go",
+              "model": "deepseek-v4-pro",
+              "tier": "quality",
+              "efforts": ["medium", "high", "max"],
+              "tasks": ["architecture", "root-cause", "hard-debug"]
+            },
+            {
+              "id": "go_qwen_max",
+              "provider": "opencode-go",
+              "model": "qwen3.7-max",
+              "tier": "quality",
+              "efforts": ["medium", "high", "max"],
+              "tasks": ["architecture", "plans", "complex-impl"]
+            }
+          ]
+        }
+      }
+    },
+    "antigravity": {
+      "canonical": false,
+      "sourceOfTruth": "claude-code",
+      "symlinkBody": true,
+      "families": [
+        {
+          "id": "flash_lite",
+          "provider": "google",
+          "model": "gemini-3.5-flash-lite",
+          "tier": "budget",
+          "efforts": ["low", "medium"],
+          "tasks": ["docs", "boilerplate"]
+        },
+        {
+          "id": "flash",
+          "provider": "google",
+          "model": "gemini-3.6-flash",
+          "tier": "balanced",
+          "efforts": ["low", "medium", "high"],
+          "tasks": ["implementation", "multimodal"]
+        },
+        {
+          "id": "pro",
+          "provider": "google",
+          "model": "gemini-3.1-pro-preview",
+          "tier": "quality",
+          "efforts": ["medium", "high", "max"],
+          "tasks": ["architecture", "multimodal-reasoning"]
+        }
+      ]
+    }
+  },
+  "taskRouting": {
+    "docs": {"tier": "budget", "effort": "low", "budgetTokens": "2k-8k", "budgetTime": "1-5min"},
+    "comments": {"tier": "budget", "effort": "low", "budgetTokens": "1k-4k", "budgetTime": "1-3min"},
+    "changelogs": {"tier": "budget", "effort": "low", "budgetTokens": "2k-6k", "budgetTime": "1-4min"},
+    "boilerplate": {"tier": "budget", "effort": "low", "budgetTokens": "2k-10k", "budgetTime": "2-8min"},
+    "mechanical-tests": {"tier": "budget", "effort": "low", "budgetTokens": "3k-12k", "budgetTime": "3-10min"},
+    "lint-fixes": {"tier": "budget", "effort": "low", "budgetTokens": "1k-6k", "budgetTime": "1-5min"},
+    "implementation": {"tier": "balanced", "effort": "medium", "budgetTokens": "8k-40k", "budgetTime": "10-40min"},
+    "refactor": {"tier": "balanced", "effort": "medium", "budgetTokens": "8k-35k", "budgetTime": "10-35min"},
+    "integration-tests": {"tier": "balanced", "effort": "medium", "budgetTokens": "6k-25k", "budgetTime": "8-25min"},
+    "multi-step-agentic": {"tier": "balanced", "effort": "high", "budgetTokens": "15k-60k", "budgetTime": "15-60min"},
+    "architecture": {"tier": "quality", "effort": "high", "budgetTokens": "20k-80k", "budgetTime": "20-90min"},
+    "plans": {"tier": "quality", "effort": "high", "budgetTokens": "15k-50k", "budgetTime": "15-45min"},
+    "root-cause": {"tier": "quality", "effort": "xhigh", "budgetTokens": "20k-100k", "budgetTime": "20-90min"},
+    "security-audit": {"tier": "quality", "effort": "high", "budgetTokens": "20k-80k", "budgetTime": "20-60min"},
+    "migration": {"tier": "quality", "effort": "high", "budgetTokens": "25k-100k", "budgetTime": "30-120min"}
+  },
   "aliases": {
     "l 5.6 lunce": {"provider": "openai", "model": "gpt-5.6-luna"},
     "gpt-5.6 lunce": {"provider": "openai", "model": "gpt-5.6-luna"},
+    "luna": {"provider": "openai", "model": "gpt-5.6-luna"},
+    "terra": {"provider": "openai", "model": "gpt-5.6-terra"},
+    "sol": {"provider": "openai", "model": "gpt-5.6-sol"},
     "kimi k3": {"provider": "moonshotai", "model": "kimi-k2"},
     "opus %": {"provider": "anthropic", "model": "claude-opus-5"},
+    "haiku": {"provider": "anthropic", "model": "claude-haiku-4-5"},
+    "sonnet": {"provider": "anthropic", "model": "claude-sonnet-5"},
+    "opus": {"provider": "anthropic", "model": "claude-opus-5"},
     "deepseek v4 flash": {"provider": "deepseek", "model": "deepseek-v4-flash"},
     "gemini 3.5 pro": {"provider": "google", "model": "gemini-2.5-pro"}
   },
@@ -71,14 +306,14 @@
       "effortField": "model_reasoning_effort"
     },
     "opencode": {
-      "configMode": "json-agent",
+      "configMode": "markdown-agent",
       "configPath": "opencode.json or ~/.config/opencode/agents/",
       "nativeProviders": ["*"],
       "effortField": "model-specific"
     },
     "antigravity": {
-      "configMode": "handoff-manifest",
-      "configPath": "manual / managed agent surface",
+      "configMode": "markdown-agent",
+      "configPath": "~/.agy/agents/",
       "nativeProviders": ["google"],
       "effortField": "managed"
     },
@@ -155,9 +390,51 @@
       "effortParameter": "reasoning.effort/model_reasoning_effort",
       "models": [
         {"id": "gpt-5.6", "displayName": "GPT-5.6", "tier": "quality", "status": "stable", "efforts": ["none", "low", "medium", "high", "xhigh", "max"], "capabilities": ["reasoning", "coding", "tools", "agentic"]},
+        {"id": "gpt-5.6-sol", "displayName": "GPT-5.6 Sol", "tier": "quality", "status": "stable", "efforts": ["none", "low", "medium", "high", "xhigh", "max"], "capabilities": ["reasoning", "coding", "tools", "agentic", "architecture"]},
         {"id": "gpt-5.6-terra", "displayName": "GPT-5.6 Terra", "tier": "balanced", "status": "stable", "efforts": ["none", "low", "medium", "high", "xhigh", "max"], "capabilities": ["coding", "tools", "fast"]},
         {"id": "gpt-5.6-luna", "displayName": "GPT-5.6 Luna", "tier": "budget", "status": "stable", "efforts": ["none", "low", "medium", "high", "xhigh", "max"], "capabilities": ["fast", "bounded", "high-throughput"]},
         {"id": "gpt-5-codex", "displayName": "GPT-5-Codex", "tier": "quality", "status": "stable", "efforts": ["low", "medium", "high", "xhigh", "max"], "capabilities": ["agentic", "coding", "tools"]}
+      ]
+    },
+    {
+      "id": "opencode",
+      "displayName": "OpenCode Zen",
+      "apiKeyEnv": "OPENCODE_API_KEY",
+      "docs": "https://opencode.ai/docs/models",
+      "effortParameter": "model-specific",
+      "models": [
+        {"id": "deepseek-v4-flash-free", "displayName": "DeepSeek V4 Flash Free", "tier": "budget", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["fast", "coding", "free"]},
+        {"id": "mimo-v2.5-free", "displayName": "Mimo V2.5 Free", "tier": "budget", "status": "stable", "efforts": ["low", "medium"], "capabilities": ["fast", "free"]},
+        {"id": "nemotron-3.5-lightning-free", "displayName": "Nemotron 3.5 Lightning Free", "tier": "budget", "status": "stable", "efforts": ["low", "medium"], "capabilities": ["fast", "free"]},
+        {"id": "gpt-5.6-luna", "displayName": "GPT-5.6 Luna (Zen)", "tier": "budget", "status": "stable", "efforts": ["low", "medium", "high", "xhigh", "max"], "capabilities": ["fast", "bounded"]},
+        {"id": "gpt-5.6-terra", "displayName": "GPT-5.6 Terra (Zen)", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high", "xhigh", "max"], "capabilities": ["coding", "tools"]},
+        {"id": "gpt-5.6-sol", "displayName": "GPT-5.6 Sol (Zen)", "tier": "quality", "status": "stable", "efforts": ["low", "medium", "high", "xhigh", "max"], "capabilities": ["reasoning", "architecture"]},
+        {"id": "claude-opus-5", "displayName": "Claude Opus 5 (Zen)", "tier": "quality", "status": "stable", "efforts": ["low", "medium", "high", "xhigh", "max"], "capabilities": ["reasoning", "coding", "agentic"]},
+        {"id": "claude-sonnet-5", "displayName": "Claude Sonnet 5 (Zen)", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high", "xhigh"], "capabilities": ["coding", "tools"]},
+        {"id": "claude-haiku-4-5", "displayName": "Claude Haiku 4.5 (Zen)", "tier": "budget", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["fast", "subagent"]},
+        {"id": "grok-4.5", "displayName": "Grok 4.5 (Zen)", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "fast-reasoning"]},
+        {"id": "grok-4.6", "displayName": "Grok 4.6 (Zen)", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "fast-reasoning"]}
+      ]
+    },
+    {
+      "id": "opencode-go",
+      "displayName": "OpenCode Go",
+      "apiKeyEnv": "OPENCODE_API_KEY",
+      "docs": "https://opencode.ai/docs/models",
+      "effortParameter": "model-specific",
+      "models": [
+        {"id": "gpt-5.6-luna", "displayName": "GPT-5.6 Luna (Go)", "tier": "budget", "status": "stable", "efforts": ["low", "medium", "high", "xhigh", "max"], "capabilities": ["fast", "bounded"]},
+        {"id": "deepseek-v4-flash", "displayName": "DeepSeek V4 Flash (Go)", "tier": "budget", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["fast", "coding"]},
+        {"id": "deepseek-v4-pro", "displayName": "DeepSeek V4 Pro (Go)", "tier": "quality", "status": "stable", "efforts": ["medium", "high", "max"], "capabilities": ["reasoning", "coding"]},
+        {"id": "grok-4.5", "displayName": "Grok 4.5 (Go)", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "fast-reasoning"]},
+        {"id": "glm-5.2", "displayName": "GLM-5.2 (Go)", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "agentic"]},
+        {"id": "glm-5.3", "displayName": "GLM-5.3 (Go)", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "agentic"]},
+        {"id": "kimi-k2.7-code", "displayName": "Kimi K2.7 Code (Go)", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "long-context"]},
+        {"id": "kimi-k3", "displayName": "Kimi K3 (Go)", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "long-context"]},
+        {"id": "qwen3.7-max", "displayName": "Qwen3.7 Max (Go)", "tier": "quality", "status": "stable", "efforts": ["medium", "high", "max"], "capabilities": ["reasoning", "coding"]},
+        {"id": "qwen3.8-max", "displayName": "Qwen3.8 Max (Go)", "tier": "quality", "status": "stable", "efforts": ["medium", "high", "max"], "capabilities": ["reasoning", "coding"]},
+        {"id": "mimo-v2.5-pro", "displayName": "Mimo V2.5 Pro (Go)", "tier": "quality", "status": "stable", "efforts": ["medium", "high", "max"], "capabilities": ["reasoning", "coding"]},
+        {"id": "minimax-m3", "displayName": "MiniMax M3 (Go)", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "tools"]}
       ]
     },
     {
@@ -187,7 +464,9 @@
       "docs": "https://opencode.ai/docs/providers",
       "effortParameter": "model-specific",
       "models": [
-        {"id": "glm-4.7", "displayName": "GLM-4.7", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "tools", "multilingual"]}
+        {"id": "glm-4.7", "displayName": "GLM-4.7", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "tools", "multilingual"]},
+        {"id": "glm-5.2", "displayName": "GLM-5.2", "tier": "balanced", "status": "stable", "efforts": ["low", "medium", "high"], "capabilities": ["coding", "tools", "multilingual"]},
+        {"id": "glm-4.5-air", "displayName": "GLM-4.5 Air", "tier": "budget", "status": "stable", "efforts": ["low", "medium"], "capabilities": ["fast", "budget"]}
       ]
     }
   ]

--- a/plugins/smart-sub-agents/scripts/install_worker_matrix.py
+++ b/plugins/smart-sub-agents/scripts/install_worker_matrix.py
@@ -265,9 +265,14 @@ def install_agy(catalog: dict, dry_run: bool) -> list[str]:
     for family in catalog["workerMatrix"]["codex"]["families"]:
         for effort in family["efforts"]:
             name = worker_name(family["id"], effort)
-            # Map codex family -> claude tier equivalent for body
-            tier_map = {"luna": "haiku", "terra": "sonnet", "sol": "opus"}
-            claude_family = tier_map[family["id"]]
+            # Map codex family -> claude tier equivalent for body via tier match
+            # (derived from provider-matrix.json, not a hand-authored dict, so it
+            # cannot drift out of sync with the catalog).
+            claude_family = next(
+                f["id"]
+                for f in catalog["workerMatrix"]["claude-code"]["families"]
+                if f["tier"] == family["tier"]
+            )
             # clamp effort to claude family efforts
             claude_efforts = next(
                 f["efforts"]
@@ -275,19 +280,22 @@ def install_agy(catalog: dict, dry_run: bool) -> list[str]:
                 if f["id"] == claude_family
             )
             mapped_effort = effort if effort in claude_efforts else claude_efforts[-1]
+            clamp_note = "" if mapped_effort == effort else f" (clamped from {effort})"
             src = claude_root / f"{worker_name(claude_family, mapped_effort)}.md"
             dst = root / f"{name}.md"
             content = f"""---
 name: {name}
 description: >
   Codex-named alias for {family['id']} @ {effort}. Body canonical from Claude
-  {claude_family}_worker_{mapped_effort}. Prefer native Codex TOML worker when
+  {claude_family}_worker_{mapped_effort}{clamp_note}. Prefer native Codex TOML worker when
   running under Codex.
 # {MANAGED_MARKER}
 ---
 
 See canonical Claude worker: `{src.name}`.
 Harness note: Agy should load Claude-equivalent tier and keep budget discipline.
+Effective effort: `{mapped_effort}`{clamp_note} — the filename says `{effort}` but the linked body
+runs at `{mapped_effort}` because Claude's `{claude_family}` family does not support `{effort}`.
 Provider target when delegated to Codex: `{family['provider']}/{family['model']}` effort `{effort}`.
 """
             results.append(write_file(dst, content, dry_run))

--- a/plugins/smart-sub-agents/scripts/install_worker_matrix.py
+++ b/plugins/smart-sub-agents/scripts/install_worker_matrix.py
@@ -19,6 +19,8 @@ import sys
 from datetime import date
 from pathlib import Path
 
+from validate_catalog import validate
+
 PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CATALOG = PLUGIN_ROOT / "references" / "provider-matrix.json"
 MANAGED_MARKER = "managed-by: smart-sub-agents/worker-matrix"
@@ -59,7 +61,11 @@ TIER_COLOR = {
 
 
 def load_catalog(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
+    catalog = json.loads(path.read_text(encoding="utf-8"))
+    errors = validate(catalog)
+    if errors:
+        raise ValueError("; ".join(errors))
+    return catalog
 
 
 def slug(value: str) -> str:
@@ -346,6 +352,17 @@ def validate_installed() -> list[str]:
             errors.append(f"{path}: missing model")
         if MANAGED_MARKER not in text:
             errors.append(f"{path}: missing managed marker")
+    # Agy: validate managed codex-named aliases only. Symlinks point to Claude
+    # canonical bodies (already validated above); non-managed files are skipped
+    # so a user's manual worker file does not trigger a false positive.
+    for path in HARNESS_DIRS["antigravity"].glob("*_worker_*.md"):
+        if path.is_symlink():
+            continue
+        text = path.read_text(encoding="utf-8")
+        if MANAGED_MARKER not in text:
+            continue
+        if not text.startswith("---"):
+            errors.append(f"{path}: missing frontmatter")
     return errors
 
 

--- a/plugins/smart-sub-agents/scripts/install_worker_matrix.py
+++ b/plugins/smart-sub-agents/scripts/install_worker_matrix.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Install the worker agent matrix across Claude, Codex, OpenCode, and Agy.
+
+Claude agents are canonical. Other harnesses get:
+- Codex: native TOML with model + model_reasoning_effort
+- OpenCode: adapted markdown (mode/permission/model provider prefix)
+- Agy: symlink body to Claude when possible, else adapted markdown
+
+Idempotent. Never deletes non-managed agents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CATALOG = PLUGIN_ROOT / "references" / "provider-matrix.json"
+MANAGED_MARKER = "managed-by: smart-sub-agents/worker-matrix"
+
+HOME = Path.home()
+HARNESS_DIRS = {
+    "claude-code": HOME / ".claude" / "agents",
+    "codex": HOME / ".codex" / "agents",
+    "opencode": HOME / ".config" / "opencode" / "agents",
+    "antigravity": HOME / ".agy" / "agents",
+}
+
+EFFORT_TOKEN_BUDGET = {
+    "none": "1k-4k",
+    "low": "2k-10k",
+    "medium": "8k-35k",
+    "high": "15k-60k",
+    "xhigh": "25k-100k",
+    "max": "40k-150k",
+    "ultra": "60k-200k",
+}
+
+EFFORT_TIME_BUDGET = {
+    "none": "1-3min",
+    "low": "2-8min",
+    "medium": "8-30min",
+    "high": "15-60min",
+    "xhigh": "20-90min",
+    "max": "30-120min",
+    "ultra": "45-180min",
+}
+
+TIER_COLOR = {
+    "budget": "#22C55E",
+    "balanced": "#3B82F6",
+    "quality": "#A855F7",
+}
+
+
+def load_catalog(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def worker_name(family_id: str, effort: str) -> str:
+    return f"{slug(family_id)}_worker_{slug(effort)}"
+
+
+def body_text(family: dict, effort: str, harness: str) -> str:
+    tasks = ", ".join(family.get("tasks", []))
+    token_budget = EFFORT_TOKEN_BUDGET.get(effort, "unknown")
+    time_budget = EFFORT_TIME_BUDGET.get(effort, "unknown")
+    return f"""# {family['id'].title()} Worker ({effort})
+
+You are a **tiered worker subagent**. Stay inside the selected route.
+
+## Route
+- harness: `{harness}`
+- provider: `{family['provider']}`
+- model: `{family['model']}`
+- effort: `{effort}`
+- tier: `{family['tier']}`
+- tasks: {tasks}
+
+## Budget contract
+- tokens: `{token_budget}`
+- time: `{time_budget}`
+- effort: `{effort}`
+- escalate only after 2 failed validation attempts, then return ROUTE-ESCALATE with next tier.
+
+## Protocol
+1. Restate the task in one line and confirm it matches the allowed tasks above.
+2. Prefer local CLI (`rtk`, lint, tsc, tests) before expanding scope.
+3. Make surgical edits only. No drive-by refactors.
+4. Verify with the cheapest command that proves success.
+5. Return: changed files, verification command+result, residual risks.
+
+## DO NOT
+- Invent provider availability or credentials.
+- Exceed the effort/token budget without explicit user approval.
+- Touch unrelated files.
+- Mark complete without verification evidence.
+"""
+
+
+def render_claude(name: str, family: dict, effort: str) -> str:
+    tasks = ", ".join(family.get("tasks", []))
+    return f"""---
+name: {name}
+description: >
+  Worker {family['id']} @ {effort} effort ({family['tier']}).
+  Use for: {tasks}.
+  Model {family['model']}. Managed by smart-sub-agents worker matrix.
+model: {family['model']}
+effort: {effort}
+color: "{TIER_COLOR.get(family['tier'], '#6B7280')}"
+mode: subagent
+# {MANAGED_MARKER}
+---
+
+{body_text(family, effort, 'claude-code')}
+"""
+
+
+def render_codex_toml(name: str, family: dict, effort: str) -> str:
+    tasks = ", ".join(family.get("tasks", []))
+    body = body_text(family, effort, "codex").replace('"""', "'''")
+    return f'''name = "{name}"
+description = "Worker {family['id']} @ {effort} ({family['tier']}). Tasks: {tasks}. Model {family['model']}."
+model = "{family['model']}"
+model_reasoning_effort = "{effort}"
+sandbox_mode = "workspace-write"
+# {MANAGED_MARKER}
+developer_instructions = """
+{body}
+"""
+'''
+
+
+def render_opencode(name: str, family: dict, effort: str, lane: str | None = None) -> str:
+    provider = family["provider"]
+    model_ref = f"{provider}/{family['model']}"
+    tasks = ", ".join(family.get("tasks", []))
+    lane_note = f" lane={lane}" if lane else ""
+    return f"""---
+name: {name}
+description: >
+  Worker {family['id']} @ {effort} ({family['tier']}){lane_note}.
+  Use for: {tasks}. Model {model_ref}.
+mode: subagent
+model: {model_ref}
+temperature: 0.1
+color: "{TIER_COLOR.get(family['tier'], '#6B7280')}"
+permission:
+  bash: allow
+  read: allow
+  edit: allow
+  glob: allow
+  grep: allow
+  webfetch: deny
+# {MANAGED_MARKER}
+---
+
+{body_text(family, effort, 'opencode')}
+"""
+
+
+def write_file(path: Path, content: str, dry_run: bool) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and path.is_symlink():
+        if dry_run:
+            return f"WOULD_REPLACE_SYMLINK {path}"
+        path.unlink()
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return f"SKIP {path}"
+    if dry_run:
+        return f"WOULD_WRITE {path}"
+    path.write_text(content, encoding="utf-8")
+    return f"WRITE {path}"
+
+
+def symlink_file(src: Path, dst: Path, dry_run: bool) -> str:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists() or dst.is_symlink():
+        if dst.is_symlink() and dst.resolve() == src.resolve():
+            return f"SKIP_LINK {dst}"
+        if dry_run:
+            return f"WOULD_RELINK {dst} -> {src}"
+        dst.unlink()
+    if dry_run:
+        return f"WOULD_LINK {dst} -> {src}"
+    os.symlink(src, dst)
+    return f"LINK {dst} -> {src}"
+
+
+def install_claude(catalog: dict, dry_run: bool) -> list[str]:
+    results: list[str] = []
+    root = HARNESS_DIRS["claude-code"]
+    matrix = catalog["workerMatrix"]["claude-code"]
+    for family in matrix["families"]:
+        for effort in family["efforts"]:
+            name = worker_name(family["id"], effort)
+            path = root / f"{name}.md"
+            results.append(write_file(path, render_claude(name, family, effort), dry_run))
+    return results
+
+
+def install_codex(catalog: dict, dry_run: bool) -> list[str]:
+    results: list[str] = []
+    root = HARNESS_DIRS["codex"]
+    matrix = catalog["workerMatrix"]["codex"]
+    for family in matrix["families"]:
+        for effort in family["efforts"]:
+            name = worker_name(family["id"], effort)
+            path = root / f"{name}.toml"
+            results.append(write_file(path, render_codex_toml(name, family, effort), dry_run))
+    return results
+
+
+def install_opencode(catalog: dict, dry_run: bool) -> list[str]:
+    results: list[str] = []
+    root = HARNESS_DIRS["opencode"]
+    lanes = catalog["workerMatrix"]["opencode"]["lanes"]
+    for lane_id, lane in lanes.items():
+        for family in lane["families"]:
+            for effort in family["efforts"]:
+                # names: go_luna_worker_high, zen_sol_worker_max
+                name = worker_name(family["id"], effort)
+                path = root / f"{name}.md"
+                results.append(write_file(path, render_opencode(name, family, effort, lane=lane_id), dry_run))
+    return results
+
+
+def install_agy(catalog: dict, dry_run: bool) -> list[str]:
+    """Agy consumes Claude canonical bodies via symlink when model-agnostic.
+
+    Worker agents are model-specific, so Agy gets adapted markdown copies that
+    mirror Claude content (same body) with Claude frontmatter kept for shared
+    skills and a note that execution should prefer Claude/Codex native workers.
+    """
+    results: list[str] = []
+    root = HARNESS_DIRS["antigravity"]
+    claude_root = HARNESS_DIRS["claude-code"]
+    # Symlink each Claude worker into Agy so body stays canonical.
+    for family in catalog["workerMatrix"]["claude-code"]["families"]:
+        for effort in family["efforts"]:
+            name = worker_name(family["id"], effort)
+            src = claude_root / f"{name}.md"
+            dst = root / f"{name}.md"
+            if not src.exists() and not dry_run:
+                results.append(f"MISSING_CANONICAL {src}")
+                continue
+            results.append(symlink_file(src, dst, dry_run))
+    # Also expose codex-named aliases as thin markdown pointers for discoverability.
+    for family in catalog["workerMatrix"]["codex"]["families"]:
+        for effort in family["efforts"]:
+            name = worker_name(family["id"], effort)
+            # Map codex family -> claude tier equivalent for body
+            tier_map = {"luna": "haiku", "terra": "sonnet", "sol": "opus"}
+            claude_family = tier_map[family["id"]]
+            # clamp effort to claude family efforts
+            claude_efforts = next(
+                f["efforts"]
+                for f in catalog["workerMatrix"]["claude-code"]["families"]
+                if f["id"] == claude_family
+            )
+            mapped_effort = effort if effort in claude_efforts else claude_efforts[-1]
+            src = claude_root / f"{worker_name(claude_family, mapped_effort)}.md"
+            dst = root / f"{name}.md"
+            content = f"""---
+name: {name}
+description: >
+  Codex-named alias for {family['id']} @ {effort}. Body canonical from Claude
+  {claude_family}_worker_{mapped_effort}. Prefer native Codex TOML worker when
+  running under Codex.
+# {MANAGED_MARKER}
+---
+
+See canonical Claude worker: `{src.name}`.
+Harness note: Agy should load Claude-equivalent tier and keep budget discipline.
+Provider target when delegated to Codex: `{family['provider']}/{family['model']}` effort `{effort}`.
+"""
+            results.append(write_file(dst, content, dry_run))
+    return results
+
+
+def symlink_canonical_specialists(dry_run: bool) -> list[str]:
+    """Keep shared specialists pointing at Claude canonical files."""
+    results: list[str] = []
+    claude = HARNESS_DIRS["claude-code"]
+    shared = [
+        "git-master.md",
+        "zai-specialist.md",
+        "thermo-nuclear-review-subagent.md",
+        "thermo-nuclear-code-quality-review-subagent.md",
+    ]
+    for harness, root in HARNESS_DIRS.items():
+        if harness == "claude-code":
+            continue
+        for name in shared:
+            src = claude / name
+            if not src.exists():
+                continue
+            # OpenCode keeps adapted copies for frontmatter; only symlink body-identical harnesses.
+            if harness == "opencode":
+                continue
+            dst = root / name
+            results.append(symlink_file(src, dst, dry_run))
+    return results
+
+
+def validate_installed() -> list[str]:
+    errors: list[str] = []
+    # Claude frontmatter
+    for path in HARNESS_DIRS["claude-code"].glob("*_worker_*.md"):
+        text = path.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            errors.append(f"{path}: missing frontmatter")
+            continue
+        if "model:" not in text.split("---", 2)[1]:
+            errors.append(f"{path}: missing model")
+        if "effort:" not in text.split("---", 2)[1]:
+            errors.append(f"{path}: missing effort")
+        if MANAGED_MARKER not in text:
+            errors.append(f"{path}: missing managed marker")
+    # Codex toml
+    for path in HARNESS_DIRS["codex"].glob("*_worker_*.toml"):
+        text = path.read_text(encoding="utf-8")
+        if 'model = "' not in text:
+            errors.append(f"{path}: missing model")
+        if "model_reasoning_effort" not in text:
+            errors.append(f"{path}: missing model_reasoning_effort")
+        if MANAGED_MARKER not in text:
+            errors.append(f"{path}: missing managed marker")
+    # OpenCode
+    for path in HARNESS_DIRS["opencode"].glob("*_worker_*.md"):
+        text = path.read_text(encoding="utf-8")
+        fm = text.split("---", 2)[1] if text.startswith("---") else ""
+        if "mode: subagent" not in fm:
+            errors.append(f"{path}: missing mode: subagent")
+        if "model:" not in fm:
+            errors.append(f"{path}: missing model")
+        if MANAGED_MARKER not in text:
+            errors.append(f"{path}: missing managed marker")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--harness", choices=["all", "claude-code", "codex", "opencode", "antigravity"], default="all")
+    parser.add_argument("--validate-only", action="store_true")
+    args = parser.parse_args()
+
+    if args.validate_only:
+        errors = validate_installed()
+        if errors:
+            for e in errors:
+                print(f"ERROR: {e}", file=sys.stderr)
+            return 1
+        print("OK: installed worker matrix validates")
+        return 0
+
+    catalog = load_catalog(args.catalog)
+    results: list[str] = []
+    harnesses = (
+        ["claude-code", "codex", "opencode", "antigravity"]
+        if args.harness == "all"
+        else [args.harness]
+    )
+    # Claude first so Agy can symlink.
+    order = ["claude-code", "codex", "opencode", "antigravity"]
+    for harness in order:
+        if harness not in harnesses:
+            continue
+        if harness == "claude-code":
+            results.extend(install_claude(catalog, args.dry_run))
+        elif harness == "codex":
+            results.extend(install_codex(catalog, args.dry_run))
+        elif harness == "opencode":
+            results.extend(install_opencode(catalog, args.dry_run))
+        elif harness == "antigravity":
+            results.extend(install_agy(catalog, args.dry_run))
+
+    results.extend(symlink_canonical_specialists(args.dry_run))
+
+    writes = sum(1 for r in results if r.startswith("WRITE") or r.startswith("LINK"))
+    skips = sum(1 for r in results if r.startswith("SKIP"))
+    for line in results:
+        print(line)
+    print(f"---\nsummary: writes/links={writes} skips={skips} total={len(results)} date={date.today().isoformat()}")
+
+    if not args.dry_run:
+        errors = validate_installed()
+        if errors:
+            for e in errors:
+                print(f"ERROR: {e}", file=sys.stderr)
+            return 1
+        print("OK: validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/smart-sub-agents/scripts/render_agents.py
+++ b/plugins/smart-sub-agents/scripts/render_agents.py
@@ -158,13 +158,39 @@ Do not invent provider availability or expose credentials.
 
 
 def render_opencode(route: dict) -> str:
+    """Render OpenCode markdown agent (preferred) plus optional json snippet."""
+    model_ref = route["modelRef"]
+    # OpenCode accepts provider/model; zen/go providers already include prefix.
+    name = agent_name(route)
+    md = f"""---
+name: {name}
+description: Dynamic subagent route for {model_ref} at {route['effort']} effort. Native mapping: {route['nativeEffort']}.
+mode: subagent
+model: {model_ref}
+temperature: 0.1
+permission:
+  bash: allow
+  read: allow
+  edit: allow
+  glob: allow
+  grep: allow
+---
+
+Use the selected route for bounded delegated work. Return evidence, changed files, and validation results.
+Requested native mapping: {route['nativeEffort']}.
+Do not invent provider availability or expose credentials.
+"""
+    return md
+
+
+def render_opencode_json(route: dict) -> str:
     agent = {
         "description": f"Dynamic subagent route for {route['modelRef']} at {route['effort']} effort. Native mapping: {route['nativeEffort']}.",
         "mode": "subagent",
         "model": route["modelRef"],
         "steps": 12 if route["effort"] in {"high", "xhigh", "max", "ultra"} else 6,
     }
-    if route["provider"] == "openai":
+    if route["provider"] in {"openai", "opencode", "opencode-go"} and route["model"].startswith("gpt-"):
         agent["reasoningEffort"] = route["effort"]
     return json.dumps({"$schema": "https://opencode.ai/config.json", "agent": {agent_name(route): agent}}, indent=2) + "\n"
 
@@ -179,7 +205,7 @@ def render(harness: str, route: dict) -> tuple[str, str]:
     if harness == "codex":
         return f"{agent_name(route)}.toml", render_codex(route)
     if harness == "opencode":
-        return "opencode.json", render_opencode(route)
+        return f"{agent_name(route)}.md", render_opencode(route)
     return "route.json", render_manifest(route)
 
 

--- a/plugins/smart-sub-agents/scripts/sync_provider_matrix.py
+++ b/plugins/smart-sub-agents/scripts/sync_provider_matrix.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Sync provider-matrix.json against live harness model catalogs.
+
+Sources:
+- OpenCode: `opencode models`
+- Optional overrides via --seed JSON
+
+Never invents models. Marks missing live models as status=stale and adds
+newly observed OpenCode Zen/Go models as status=discovered (manual promote).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CATALOG = PLUGIN_ROOT / "references" / "provider-matrix.json"
+
+
+def run_opencode_models() -> list[str]:
+    try:
+        result = subprocess.run(
+            ["opencode", "models"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        print(f"WARN: opencode models unavailable: {exc}", file=sys.stderr)
+        return []
+    if result.returncode != 0:
+        print(f"WARN: opencode models exit {result.returncode}: {result.stderr}", file=sys.stderr)
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip() and "/" in line]
+
+
+def parse_model_ref(ref: str) -> tuple[str, str]:
+    provider, model = ref.split("/", 1)
+    return provider, model
+
+
+def ensure_provider(catalog: dict, provider_id: str) -> dict:
+    for provider in catalog["providers"]:
+        if provider["id"] == provider_id:
+            return provider
+    provider = {
+        "id": provider_id,
+        "displayName": provider_id,
+        "apiKeyEnv": f"{provider_id.upper().replace('-', '_')}_API_KEY",
+        "docs": "https://opencode.ai/docs/models",
+        "effortParameter": "model-specific",
+        "models": [],
+    }
+    catalog["providers"].append(provider)
+    return provider
+
+
+def tier_guess(model_id: str) -> str:
+    low = model_id.lower()
+    if any(x in low for x in ("flash", "lite", "nano", "mini", "free", "luna", "haiku", "air")):
+        return "budget"
+    if any(x in low for x in ("opus", "sol", "pro", "max", "fable", "ultra")):
+        return "quality"
+    return "balanced"
+
+
+def sync_opencode(catalog: dict, live: list[str]) -> dict:
+    report = {"live": len(live), "added": [], "stale": [], "kept": []}
+    live_by_provider: dict[str, set[str]] = {}
+    for ref in live:
+        provider, model = parse_model_ref(ref)
+        if provider not in {"opencode", "opencode-go"}:
+            continue
+        live_by_provider.setdefault(provider, set()).add(model)
+
+    for provider_id, models in live_by_provider.items():
+        provider = ensure_provider(catalog, provider_id)
+        known = {m["id"]: m for m in provider["models"]}
+        for model_id in sorted(models):
+            if model_id in known:
+                known[model_id]["status"] = "stable"
+                report["kept"].append(f"{provider_id}/{model_id}")
+            else:
+                entry = {
+                    "id": model_id,
+                    "displayName": model_id,
+                    "tier": tier_guess(model_id),
+                    "status": "discovered",
+                    "efforts": ["low", "medium", "high"],
+                    "capabilities": ["discovered-via-opencode-models"],
+                }
+                provider["models"].append(entry)
+                report["added"].append(f"{provider_id}/{model_id}")
+        for model_id, entry in known.items():
+            if model_id not in models and entry.get("status") != "discovered":
+                entry["status"] = "stale"
+                report["stale"].append(f"{provider_id}/{model_id}")
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--write", action="store_true", help="persist catalog updates")
+    parser.add_argument("--json", action="store_true", help="print machine report")
+    args = parser.parse_args()
+
+    catalog = json.loads(args.catalog.read_text(encoding="utf-8"))
+    live = run_opencode_models()
+    report = {"date": date.today().isoformat(), "opencode": sync_opencode(catalog, live)}
+    catalog["updated"] = date.today().isoformat()
+
+    if args.write:
+        args.catalog.write_text(json.dumps(catalog, indent=2) + "\n", encoding="utf-8")
+        # re-validate
+        validator = PLUGIN_ROOT / "scripts" / "validate_catalog.py"
+        result = subprocess.run([sys.executable, str(validator), "--catalog", str(args.catalog)], capture_output=True, text=True)
+        report["validate"] = {"code": result.returncode, "stdout": result.stdout.strip(), "stderr": result.stderr.strip()}
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr)
+            return 1
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        oc = report["opencode"]
+        print(f"date={report['date']}")
+        print(f"opencode live={oc['live']} kept={len(oc['kept'])} added={len(oc['added'])} stale={len(oc['stale'])}")
+        if oc["added"]:
+            print("added:")
+            for item in oc["added"][:40]:
+                print(f"  + {item}")
+        if oc["stale"]:
+            print("stale:")
+            for item in oc["stale"][:40]:
+                print(f"  ~ {item}")
+        if args.write:
+            print(f"wrote {args.catalog}")
+            print(report.get("validate", {}).get("stdout", ""))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/smart-sub-agents/scripts/sync_provider_matrix.py
+++ b/plugins/smart-sub-agents/scripts/sync_provider_matrix.py
@@ -64,6 +64,10 @@ def ensure_provider(catalog: dict, provider_id: str) -> dict:
 
 def tier_guess(model_id: str) -> str:
     low = model_id.lower()
+    # minimax models are balanced-tier in the catalog; guard before the "mini"
+    # substring check below would misclassify them as budget.
+    if "minimax" in low:
+        return "balanced"
     if any(x in low for x in ("flash", "lite", "nano", "mini", "free", "luna", "haiku", "air")):
         return "budget"
     if any(x in low for x in ("opus", "sol", "pro", "max", "fable", "ultra")):

--- a/plugins/smart-sub-agents/scripts/validate_catalog.py
+++ b/plugins/smart-sub-agents/scripts/validate_catalog.py
@@ -105,6 +105,13 @@ def validate(catalog: dict) -> list[str]:
                 )
             if family.get("tier") not in TIERS:
                 errors.append(f"workerMatrix {harness_id}/{family.get('id')}: invalid tier")
+            elif family.get("tier") != models_by_key[key].get("tier"):
+                errors.append(
+                    f"workerMatrix {harness_id}/{family.get('id')}: tier {family.get('tier')!r} does not match "
+                    f"canonical tier {models_by_key[key].get('tier')!r} of {key[0]}/{key[1]} "
+                    "(cost-tier mismatch — a mislabeled family can route budget-tier volume to a "
+                    "quality-priced model or vice versa)"
+                )
 
     task_routing = catalog.get("taskRouting", {})
     for task_name, route in task_routing.items():

--- a/plugins/smart-sub-agents/scripts/validate_catalog.py
+++ b/plugins/smart-sub-agents/scripts/validate_catalog.py
@@ -81,6 +81,38 @@ def validate(catalog: dict) -> list[str]:
             elif profile.get("effort") not in models_by_key[key].get("efforts", []):
                 errors.append(f"profile {profile_name}/{harness}: effort unsupported by {key[0]}/{key[1]}")
 
+    # Optional worker matrix (Claude canonical + per-harness families/lanes)
+    worker_matrix = catalog.get("workerMatrix", {})
+    for harness_id, matrix in worker_matrix.items():
+        if harness_id not in harnesses:
+            errors.append(f"workerMatrix: unknown harness {harness_id}")
+            continue
+        families = matrix.get("families", [])
+        if "lanes" in matrix:
+            for lane_id, lane in matrix["lanes"].items():
+                families = families + lane.get("families", [])
+        for family in families:
+            key = (family.get("provider", ""), family.get("model", ""))
+            if key not in models_by_key:
+                errors.append(f"workerMatrix {harness_id}/{family.get('id')}: unknown model {key[0]}/{key[1]}")
+                continue
+            family_efforts = set(family.get("efforts", []))
+            if not family_efforts or not family_efforts <= efforts:
+                errors.append(f"workerMatrix {harness_id}/{family.get('id')}: invalid efforts")
+            elif not family_efforts <= set(models_by_key[key].get("efforts", [])):
+                errors.append(
+                    f"workerMatrix {harness_id}/{family.get('id')}: effort not supported by {key[0]}/{key[1]}"
+                )
+            if family.get("tier") not in TIERS:
+                errors.append(f"workerMatrix {harness_id}/{family.get('id')}: invalid tier")
+
+    task_routing = catalog.get("taskRouting", {})
+    for task_name, route in task_routing.items():
+        if route.get("tier") not in TIERS:
+            errors.append(f"taskRouting {task_name}: invalid tier")
+        if route.get("effort") not in efforts:
+            errors.append(f"taskRouting {task_name}: invalid effort")
+
     return errors
 
 

--- a/plugins/smart-sub-agents/tests/test_catalog.py
+++ b/plugins/smart-sub-agents/tests/test_catalog.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import importlib.util
+import json
 import subprocess
 import sys
 import tempfile
@@ -7,8 +9,19 @@ from pathlib import Path
 
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[1]
-VALIDATOR = PLUGIN_ROOT / "scripts" / "validate_catalog.py"
-RENDERER = PLUGIN_ROOT / "scripts" / "render_agents.py"
+SCRIPTS_DIR = PLUGIN_ROOT / "scripts"
+VALIDATOR = SCRIPTS_DIR / "validate_catalog.py"
+RENDERER = SCRIPTS_DIR / "render_agents.py"
+INSTALLER = SCRIPTS_DIR / "install_worker_matrix.py"
+SYNCER = SCRIPTS_DIR / "sync_provider_matrix.py"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 class SmartSubAgentsCatalogTests(unittest.TestCase):
@@ -63,6 +76,52 @@ class SmartSubAgentsCatalogTests(unittest.TestCase):
         result = self.run_cli(RENDERER, "--harness", "opencode", "--provider", "openai", "--model", "gpt-5.6-lunce")
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("unknown model", result.stderr)
+
+
+class InstallHelperTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+        cls.installer = _load_module("install_worker_matrix", INSTALLER)
+
+    def test_slug_normalizes_punctuation(self) -> None:
+        self.assertEqual(self.installer.slug("Go Luna #1!"), "go_luna_1")
+
+    def test_worker_name_format(self) -> None:
+        self.assertEqual(self.installer.worker_name("go_luna", "high"), "go_luna_worker_high")
+
+    def test_load_catalog_fails_closed_on_invalid_matrix(self) -> None:
+        bad = {
+            "schemaVersion": 99,
+            "updated": "not-a-date",
+            "efforts": [],
+            "harnesses": {},
+            "providers": [],
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(bad, f)
+            catalog_path = Path(f.name)
+        try:
+            with self.assertRaises(ValueError):
+                self.installer.load_catalog(catalog_path)
+        finally:
+            catalog_path.unlink(missing_ok=True)
+
+
+class SyncHelperTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+        cls.syncer = _load_module("sync_provider_matrix", SYNCER)
+
+    def test_tier_guess_minimax_is_balanced(self) -> None:
+        self.assertEqual(self.syncer.tier_guess("minimax-m3"), "balanced")
+
+    def test_tier_guess_flash_is_budget(self) -> None:
+        self.assertEqual(self.syncer.tier_guess("gemini-3.6-flash"), "budget")
+
+    def test_tier_guess_sol_is_quality(self) -> None:
+        self.assertEqual(self.syncer.tier_guess("gpt-5.6-sol"), "quality")
 
 
 if __name__ == "__main__":

--- a/plugins/smart-sub-agents/tests/test_catalog.py
+++ b/plugins/smart-sub-agents/tests/test_catalog.py
@@ -77,6 +77,28 @@ class SmartSubAgentsCatalogTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("unknown model", result.stderr)
 
+    def test_worker_matrix_tier_mismatch_fails_closed(self) -> None:
+        """Regression: a workerMatrix family tier that disagrees with the model's
+        own canonical tier must fail validation. Otherwise a family can silently
+        route budget-tier volume to a quality-priced model (or vice versa) — the
+        exact cost-leak vector reported against opencode-go/zen worker families
+        pointing at Anthropic/OpenAI-owned model ids."""
+        catalog = json.loads((PLUGIN_ROOT / "references" / "provider-matrix.json").read_text(encoding="utf-8"))
+        for lane in catalog["workerMatrix"]["opencode"]["lanes"].values():
+            for family in lane["families"]:
+                if family["id"] == "zen_opus":
+                    family["tier"] = "budget"  # tamper: claude-opus-5 is quality
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(catalog, f)
+            catalog_path = Path(f.name)
+        try:
+            result = self.run_cli(VALIDATOR, "--catalog", str(catalog_path))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("tier", result.stderr)
+            self.assertIn("does not match", result.stderr)
+        finally:
+            catalog_path.unlink(missing_ok=True)
+
 
 class InstallHelperTests(unittest.TestCase):
     @classmethod

--- a/plugins/smart-sub-agents/tests/test_catalog.py
+++ b/plugins/smart-sub-agents/tests/test_catalog.py
@@ -18,7 +18,14 @@ class SmartSubAgentsCatalogTests(unittest.TestCase):
     def test_catalog_is_valid(self) -> None:
         result = self.run_cli(VALIDATOR)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("8 providers", result.stdout)
+        self.assertRegex(result.stdout, r"\d+ providers")
+        self.assertIn("harnesses", result.stdout)
+
+    def test_sol_route_renders(self) -> None:
+        result = self.run_cli(RENDERER, "--harness", "codex", "--provider", "openai", "--model", "gpt-5.6-sol", "--effort", "xhigh")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('model = "gpt-5.6-sol"', result.stdout)
+        self.assertIn('model_reasoning_effort = "xhigh"', result.stdout)
 
     def test_alias_normalizes_lunce_to_luna(self) -> None:
         result = self.run_cli(RENDERER, "--harness", "codex", "--model", "gpt-5.6 lunce", "--effort", "low")


### PR DESCRIPTION
## Summary

Versions the cross-harness **worker matrix** for `plugins/smart-sub-agents` so any maintainer machine can reproduce the same tier x effort named-worker grid across Claude, Codex, OpenCode, and Agy. Claude bodies stay canonical; Codex gets native TOML; OpenCode gets adapted markdown (Zen free + Go subscription lanes); Agy symlinks Claude + exposes Codex-named aliases. Adds an idempotent installer, a non-mutating `--validate-only`, and a monthly/weekly sync that reconciles the catalog against live `opencode models` (discovered/stale) without inventing model IDs.

Syncs `marketplace.json` (`smart-sub-agents` 1.0.0 -> 1.1.0) to match `plugin.json` and reflect the new worker-matrix/install/sync surface, per `docs/rules/marketplace-sync.md`.

## Architecture

```mermaid
flowchart LR
  subgraph Source["Source of truth (repo)"]
    PM["references/provider-matrix.json\nproviders, models, harnesses\nworkerMatrix + taskRouting + aliases"]
  end

  subgraph Tooling["scripts/ (non-mutating by default)"]
    VAL["validate_catalog.py"]
    REN["render_agents.py"]
    INS["install_worker_matrix.py"]
    SYN["sync_provider_matrix.py"]
  end

  subgraph Harnesses["Local harness agent dirs"]
    CL["~/.claude/agents/*.md\nhaiku/sonnet/opus_worker_*"]
    CX["~/.codex/agents/*.toml\nluna/terra/sol_worker_*"]
    OC["~/.config/opencode/agents/*.md\nzen_* / go_* _worker_*"]
    AG["~/.agy/agents/*\nsymlink -> Claude + codex aliases"]
  end

  PM --> VAL
  PM --> REN
  PM --> INS
  VAL -->|"gate"| REN
  VAL -->|"gate"| INS
  INS --> CL
  INS --> CX
  INS --> OC
  INS -->|"symlink body"| AG
  REN -->|".smart-sub-agents/generated"| OUT["preview only\n(no global write)"]

  LIVE["opencode models (live)"] --> SYN
  SYN -->|"discovered/stale"| PM
```

## Worker tiers and routing

```mermaid
flowchart TB
  REQ["task request"] --> DISP["smart-dispatch\nDISPATCH budget contract"]
  DISP --> ROUT{"tier?"}
  ROUT -->|"budget"| WB["haiku_worker / luna_worker / zen_flash / go_luna"]
  ROUT -->|"balanced"| WBAL["sonnet_worker / terra_worker / zen_terra / go_glm"]
  ROUT -->|"quality"| WQ["opus_worker / sol_worker / zen_sol / go_qwen_max"]
  WB --> ESC{"verify passes?"}
  WBAL --> ESC
  WQ --> ESC
  ESC -->|"yes"| DONE["return evidence"]
  ESC -->|"no, <2 fails"| RETRY["same worker retry"]
  RETRY --> ESC
  ESC -->|"no, 2 fails"| UP["escalate next tier"]
  UP --> ROUT
```

## Setup and sync flow

```mermaid
stateDiagram-v2
  [*] --> Validate: validate_catalog.py
  Validate --> Tests: unittest discover
  Tests --> SyncDry: sync_provider_matrix.py (dry)
  SyncDry --> Review: human promote discovered
  Review --> SyncWrite: sync --write
  SyncWrite --> Validate2: re-validate
  Validate2 --> Install: install_worker_matrix.py
  Install --> ValidateInstalled: install --validate-only
  ValidateInstalled --> [*]
```

## What changed

- `references/provider-matrix.json` — `workerMatrix` (Claude canonical, Codex, OpenCode Zen/Go lanes, Agy sourceOfTruth) + `taskRouting` budget/time maps.
- `scripts/validate_catalog.py` — validates `workerMatrix` families/lanes/efforts and `taskRouting`.
- `scripts/install_worker_matrix.py` — idempotent installer, Agy symlinks Claude, `--validate-only` non-mutating gate.
- `scripts/sync_provider_matrix.py` — reconcile against live `opencode models`, `discovered`/`stale`, never invent IDs.
- `scripts/render_agents.py` — renderer gating via the validator.
- `SKILL.md` + `plugins/smart-dispatch/SKILL.md` — worker naming contract and `DISPATCH` budget contract.
- `README.md` — setup flow + monthly/weekly sync cadence.
- `tests/test_catalog.py` — covers validator, renderer, alias normalization, unknown model fails closed.
- `.claude-plugin/marketplace.json` — `smart-sub-agents` 1.0.0 -> 1.1.0 + description/keywords (per marketplace-sync rule).

## Verify evidence

- `python3 plugins/smart-sub-agents/scripts/validate_catalog.py` -> `OK: 10 providers, 48 models, 6 harnesses`
- `python3 -m unittest discover -s plugins/smart-sub-agents/tests -p 'test_*.py'` -> `Ran 7 tests ... OK`
- marketplace version match: `plugin.json 1.1.0 == marketplace.json 1.1.0`

## Naming contract (reference)

| Harness | Pattern | Example |
| --- | --- | --- |
| Claude (canonical) | `{haiku\|sonnet\|opus}_worker_{effort}` | `sonnet_worker_high` |
| Codex | `{luna\|terra\|sol}_worker_{effort}` | `luna_worker_max` |
| OpenCode Zen | `zen_{family}_worker_{effort}` | `zen_sol_worker_max` |
| OpenCode Go | `go_{family}_worker_{effort}` | `go_luna_worker_high` |
| Agy | symlink -> Claude + codex-named aliases | `opus_worker_high` -> `~/.claude/agents/...` |

Generated files carry the marker `managed-by: smart-sub-agents/worker-matrix`; the installer never deletes non-managed agents.

## Constraints honored

- Surgical edits inside `plugins/smart-sub-agents/` and `plugins/smart-dispatch/`; marketplace sync mandated by `docs/rules/marketplace-sync.md`.
- No invented model IDs; only what the matrix or `opencode models` confirms.
- No secrets, no force-push, no deploy.