### PR TITLE
feat(app-store-review): add cross-platform rejection guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -172,6 +172,29 @@
       ]
     },
     {
+      "name": "app-store-review",
+      "source": "./plugins/app-store-review",
+      "description": "Prepare for Apple App Store review and prevent rejections across native and React Native/Expo/EAS apps. Covers review guidelines, PrivacyInfo.xcprivacy, IAP and StoreKit, ATT, metadata, screenshots, App Store Connect pipeline gates, RevenueCat entitlement races, and field-tested rejection patterns.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "app-store-review",
+        "app-store",
+        "apple",
+        "ios",
+        "react-native",
+        "expo",
+        "eas",
+        "revenuecat",
+        "iap",
+        "privacy",
+        "metadata",
+        "app-review-rejections"
+      ]
+    },
+    {
       "name": "apple-store-release-agent",
       "source": "./plugins/apple-store-release-agent",
       "description": "AI release agent for the Apple App Store. Audits Expo/React Native iOS builds, App Store metadata, App Privacy readiness, TestFlight, RevenueCat/IAP, Firebase, i18n parity, screenshots, and review notes, then emits a GO/GO_WITH_WARNINGS/NO_GO decision with full risk + privacy + IAP reports. Never submits to App Review or alters the store without explicit human approval. Generic core with presets for Expo/RN/Firebase/RevenueCat apps.",

--- a/plugins/app-store-connect-api/skills/app-metadata/SKILL.md
+++ b/plugins/app-store-connect-api/skills/app-metadata/SKILL.md
@@ -137,3 +137,10 @@ Use these endpoints to automate app metadata tasks within Apple Store Connect.
 - Always authenticate requests using your Apple Store Connect API key (JWT token).
 - Handle rate limiting gracefully, as the Apple Store Connect API enforces quotas.
 - When writing integrations, refer back to the exact schemas for precise payload construction.
+
+## App Review metadata audit
+
+- Age Rating answers must declare only controls and features a reviewer can locate and operate in the candidate build. Prefer `None` over a claim that depends on an explanation outside the app.
+- Treat every screenshot set as an independent matrix of locale × device family × size × orientation. Audit via App Store Connect's **View All Sizes in Media Manager**; the binary language does not select the metadata locale.
+- Screenshots must be captured from the candidate build, not mockups, promotional renders, or Android device chrome. Re-capture every affected slot when the reviewed UI changes.
+- `app-store-review` owns the rejection-risk decision; this skill owns the App Store Connect metadata resources and upload operations.

--- a/plugins/app-store-connect-api/skills/in-app-purchases/SKILL.md
+++ b/plugins/app-store-connect-api/skills/in-app-purchases/SKILL.md
@@ -300,3 +300,13 @@ Use these endpoints to automate in-app purchases tasks within Apple Store Connec
 - Always authenticate requests using your Apple Store Connect API key (JWT token).
 - Handle rate limiting gracefully, as the Apple Store Connect API enforces quotas.
 - When writing integrations, refer back to the exact schemas for precise payload construction.
+
+## App Review metadata guardrails
+
+When IAP resources are being prepared for App Review, keep the API operation and the compliance decision separate:
+
+- Each localized IAP display name is unique within its locale and stays at or below 30 characters.
+- Each localized IAP description is unique within its locale and stays at or below 45 characters.
+- If promoted IAP images are duplicated, the lowest-cost remediation is to delete the image with `DELETE /v1/promotedPurchaseImages/{id}` rather than inventing a new asset.
+- A `409 UNMODIFIABLE` response can occur while the app version is `WAITING_FOR_REVIEW`; remove the submission from review before editing locked metadata, then re-check the linked IAPs and screenshots.
+- Audit every product × locale pair before a submission. App Store review compliance belongs to `app-store-review`; this skill supplies the API operations only.

--- a/plugins/app-store-connect-api/skills/subscriptions/SKILL.md
+++ b/plugins/app-store-connect-api/skills/subscriptions/SKILL.md
@@ -633,3 +633,10 @@ Use these endpoints to automate subscriptions tasks within Apple Store Connect.
 - Always authenticate requests using your Apple Store Connect API key (JWT token).
 - Handle rate limiting gracefully, as the Apple Store Connect API enforces quotas.
 - When writing integrations, refer back to the exact schemas for precise payload construction.
+
+## App Review subscription guardrails
+
+- Configure a Terms of Use URL for every subscription where the App Store Connect schema exposes that field, and keep it aligned with the app-level EULA and every localized description.
+- Before review, verify both Terms of Use and Privacy URLs return HTTP 200 and are reachable from inside the app.
+- In the paywall, the billed subscription amount must be the largest typographic element in the plan card. A calculated per-period amount is subordinate in size and position, and must be computed from the live product price rather than hardcoded per locale.
+- Use `app-store-review` for the compliance audit; use this skill for the subscription API resources and relationships.

--- a/plugins/app-store-connect-api/skills/testflight/SKILL.md
+++ b/plugins/app-store-connect-api/skills/testflight/SKILL.md
@@ -905,3 +905,14 @@ Use these endpoints to automate testflight tasks within Apple Store Connect.
 - Always authenticate requests using your Apple Store Connect API key (JWT token).
 - Handle rate limiting gracefully, as the Apple Store Connect API enforces quotas.
 - When writing integrations, refer back to the exact schemas for precise payload construction.
+
+## Build and submission state model
+
+Keep these states distinct when auditing a candidate for App Review:
+
+1. The cloud build finished and has a processed build number.
+2. The submit process completed for that build.
+3. The build is attached to the target App Store version.
+4. `Update Review` was submitted.
+
+Use the build and App Store Version relationships to verify each transition; an EAS `finished` status proves only the first state. Before the fourth state, verify the build number is monotonic and single-use, the fix commit is an ancestor of the build revision, and the lockfile passes `npm ci` on the CI Node major. Stop before `Update Review` for explicit account-owner confirmation. See `app-store-review` for the complete rejection-prevention checklist.

--- a/plugins/app-store-review/SKILL.md
+++ b/plugins/app-store-review/SKILL.md
@@ -1,0 +1,406 @@
+---
+name: app-store-review
+description: "Prepare for Apple App Store review and prevent rejections. Covers generic App Review guidelines, PrivacyInfo.xcprivacy and required-reason APIs, ATT, EU DMA, HIG, metadata, screenshots, entitlements, StoreKit/IAP, widgets, Live Activities, and submission workflow. Includes React Native, Expo, EAS, and RevenueCat field patterns: dead buttons without onPress, auth listener null-flash login loops, entitlement locked after sandbox purchase, subscription price hierarchy, duplicate IAP metadata, pre-permission button copy, screenshot slot audits, build number and lockfile pipeline gates, and App Store Connect API automation limits. Use when preparing for submission, responding to an App Review rejection, fixing rejection reasons, auditing privacy/metadata/IAP, implementing ATT, or debugging why premium stays locked after purchase."
+---
+
+# App Store Review Preparation
+
+Guidance for catching App Store rejection risks before submission. Apple's May 2026 fraud-prevention update says App Review evaluated more than 9.1 million submissions in 2025 and rejected more than 2 million, so treat rejection prevention as a normal release-readiness step and re-check official Apple sources before quoting annual statistics.
+
+## Contents
+
+- [Overview](#overview)
+- [Top Rejection Reasons and How to Avoid Them](#top-rejection-reasons-and-how-to-avoid-them)
+- [Field-Tested Rejection Patterns (React Native / Expo / EAS)](#field-tested-rejection-patterns-react-native--expo--eas)
+- [PrivacyInfo.xcprivacy -- Privacy Manifest Requirements](#privacyinfoxcprivacy-privacy-manifest-requirements)
+- [Data Use, Sharing, and Privacy Policy (Guideline 5.1.2)](#data-use-sharing-and-privacy-policy-guideline-512)
+- [In-App Purchase and StoreKit Rules (Guideline 3.1.1)](#in-app-purchase-and-storekit-rules-guideline-311)
+- [HIG Compliance Checklist](#hig-compliance-checklist)
+- [App Tracking Transparency (ATT)](#app-tracking-transparency-att)
+- [EU Digital Markets Act (DMA) Considerations](#eu-digital-markets-act-dma-considerations)
+- [Entitlements and Capabilities](#entitlements-and-capabilities)
+- [Submission Workflow](#submission-workflow)
+- [Metadata Best Practices](#metadata-best-practices)
+- [Appeal Process](#appeal-process)
+- [Common Mistakes](#common-mistakes)
+- [Review Checklist](#review-checklist)
+- [References](#references)
+
+## Overview
+
+Use this SKILL.md for quick guidance on common rejection reasons and key policies. Use the references for detailed checklists and privacy manifest specifics.
+
+For prompts about keywords, screenshot captions, product-page metadata, or metadata rejection risk, answer from a compliance angle and explicitly defer keyword research, ranking strategy, conversion optimization, screenshot ordering, and A/B testing to `app-store-optimization`. Keep App Review metadata guidance limited to accuracy, field limits, misleading-content risk, and screenshot compliance. Always surface the rejection-prone format checks: app name 30 characters, subtitle 30 characters, keyword field 100 characters with comma-separated keywords and no spaces after commas, screenshots showing actual app UI, 6.9-inch iPhone screenshots as the primary current iPhone set, and 13-inch iPad screenshots when the app runs on iPad.
+
+For full submission readiness audits, separate blocking upload/review issues from ordinary cleanup. Treat Xcode 26+ with the relevant platform SDK 26+ as a blocking App Store Connect upload requirement after April 28, 2026. Cross-check privacy manifests, App Store privacy nutrition labels, privacy policy, ATT state, runtime network behavior, and SDK behavior against each other; the declarations and observed behavior must align.
+
+### Blocking Submission Checks
+
+Escalate these as blockers before ordinary cleanup:
+
+- Uploads after April 28, 2026 that are not built with Xcode 26+ and the relevant platform SDK 26+
+- Privacy manifest, privacy label, privacy policy, ATT state, SDK transmissions, or audited runtime network behavior mismatches
+- Digital goods and subscriptions that bypass StoreKit IAP, or external purchase paths/links/buttons/CTAs for digital goods, unless current rules or approved entitlements allow them
+- Missing required screenshot sets: 6.9-inch iPhone screenshots, and 13-inch iPad screenshots when the app runs on iPad
+- Login-gated or non-obvious features without demo credentials, demo mode, and clear App Review notes
+
+## Top Rejection Reasons and How to Avoid Them
+
+### Guideline 2.1 -- App Completeness
+
+The app must be fully functional when reviewed. Apple rejects for:
+
+- Placeholder content, lorem ipsum, or test data visible anywhere
+- Broken links or empty screens
+- Features behind logins without demo credentials provided in App Review notes
+- Features that require hardware Apple does not have access to
+
+**Prevention:**
+- Provide demo account credentials in the App Review Information notes field in App Store Connect
+- Walk through every screen and verify real content is present
+- Test all flows end-to-end, including edge cases like empty states and error conditions
+
+### Guideline 2.3 -- Accurate Metadata
+
+- App name must match what the app actually does
+- Screenshots must show the actual app UI, not marketing renders or mockups
+- Description must not contain prices (they vary by region)
+- No references to other platforms ("Also available on Android")
+- Keywords must be relevant -- no competitor names or unrelated terms
+- Category must match the app's primary function
+
+### Guideline 4.2 -- Minimum Functionality
+
+Apple rejects apps that are too simple or are just websites in a wrapper:
+
+- WKWebView-only apps are rejected unless they add meaningful native functionality
+- Single-feature apps may be rejected if the feature is better suited as part of another app
+- Apps that duplicate built-in iOS functionality without significant improvement are rejected
+
+### Guideline 2.5.1 -- Software Requirements
+
+- Must use public APIs only -- private API usage is an instant rejection
+- As of April 28, 2026, uploads to App Store Connect must be built with Xcode 26 or later using the relevant platform SDK 26 or later
+- Deployment target support is a product and compatibility decision, not an App Review rule
+- Must not download or execute code that introduces or changes app features or functionality after review, except where Apple guidelines and agreements explicitly allow interpreted code
+
+## Field-Tested Rejection Patterns (React Native / Expo / EAS)
+
+These are rejections that actually occurred across five consecutive review cycles on a production RN + Expo + EAS + RevenueCat app, with confirmed root causes. The generic guidelines above tell you the rule; these tell you how cross-platform stacks break it.
+
+**See:** [references/field-lessons-rn-expo.md](references/field-lessons-rn-expo.md) for full root-cause analysis, code diffs, and the complete gate script.
+
+### The meta-lessons
+
+1. **Expect multiple rounds.** Each fix surfaced the next layer. Front-load the entire checklist rather than fixing only the cited findings.
+2. **The same guideline recurs for different root causes.** 2.1(a) was an auth bug in one cycle and a missing `onPress` in another. Re-diagnose from scratch; never assume a regression.
+3. **iPad is the review device.** Every finding in that timeline came from an iPad Air 11-inch. Several bugs reproduced *only* there (sheet animation races, release-build event batching). iPhone-only testing is not coverage.
+4. **Release builds behave differently.** The auth bug was invisible in dev builds; JS bridge batching changed native event ordering. Smoke-test a release/TestFlight build.
+5. **Verify the reviewed binary contains the fix.** One rejection repeated purely because the reviewed build predated the fix commit. A fix on `main` proves nothing about the binary Apple tested.
+
+### High-frequency root causes
+
+| Guideline | Failure | Root cause | Gate |
+|---|---|---|---|
+| 2.1(a) | Button does nothing | `accessibilityRole="button"` with no `onPress` | grep for interactive elements missing a handler |
+| 2.1(a) | "Rate app" inert | native review prompt is a silent no-op in review builds and rate-limited | always fall back to the App Store product page URL |
+| 2.1(a) | Confirmation never appears | nested confirmation sheets race the first sheet's dismissal on iPad | one confirmation at a time |
+| 2.1(a) | Login bounces back to login | auth SDK emits a transient `null` that lands after the sign-in completes | settle/revalidate before clearing a session |
+| 2.1(b) | Premium locked after purchase | entitlement read only from a backend webhook that has not processed yet | invalidate cache, retry with backoff, fall back to local `customerInfo` |
+| 3.1.2(c) | Price hierarchy | calculated per-month figure rendered at the same weight as the billed amount | billed amount is the largest element in the card |
+| 2.3.2 | Duplicate IAP metadata | display name/description identical across products, per locale | diff every product × locale pair |
+| 2.3.6 | Age rating overclaims | declared a control the reviewer could not find | set to `None` unless the feature is front-and-center |
+| 2.3.3 / 2.3.10 | Screenshots | marketing mockups, non-iOS status bars, stale slots | capture from the candidate build; audit via View All Sizes in Media Manager |
+| 5.1.1(iv) | Permission copy | pre-permission button said "Grant Permission" | use "Continue" / "Next"; change `accessibilityLabel` too |
+| 5.1.1(ix) | Account type | individual enrollment for a regulated-category app | not fixable in code — resolve enrollment first |
+| 4.8 | Login services | third-party login without an equivalent privacy-preserving option | add Sign in with Apple |
+
+### Pipeline gates that block submission regardless of code
+
+- **Paid Applications Agreement must be `Active`** — pending banking or tax means no purchase works, including the reviewer's.
+- **Build numbers are monotonic and single-use** — verify the last accepted build via the App Store Connect API before submitting.
+- **`npm ci` fails on any lockfile drift** — regenerate the lock on the CI Node major and commit both files together.
+- **Four distinct states, routinely conflated:** cloud build finished ≠ submit processed ≠ build attached to the version ≠ Update Review submitted.
+- **Sandbox testers cannot be created via the API** (`404 PATH_ERROR`) — App Store Connect UI only.
+- **Stop before `Update Review`** and get explicit owner confirmation. Same for replying to the reviewer and releasing.
+
+## PrivacyInfo.xcprivacy -- Privacy Manifest Requirements
+
+A privacy manifest is required when your app code, an executable, a dynamic library, or a third-party SDK uses Apple's required-reason API categories or declares collected data/tracking behavior.
+
+**See:** [references/privacy-manifest.md](references/privacy-manifest.md) for the full structure, reason codes, and checklists.
+
+### Summary
+
+- Required-reason API categories are file timestamps, system boot time, disk space, active keyboards, and UserDefaults; each requires an approved reason code when used.
+- Before final submission, re-check Apple's current required-reason API documentation and do not choose broad, convenient, or invented reason codes.
+- Required-reason API declarations belong in the bundle that contains the code using the API; every app target, executable, dynamic library, framework, or SDK bundle containing manifest-relevant code needs the matching manifest declarations.
+- Each SDK, executable, or dynamic library that collects data, uses required-reason APIs, enables data collection/tracking, or contacts tracking domains needs manifest attention in the bundle containing that code; SDK code cannot rely on the host app's manifest to report the SDK's own usage.
+- Manifest declarations must match App Store privacy nutrition labels, SDK behavior, and the app's presented functionality.
+
+## Data Use, Sharing, and Privacy Policy (Guideline 5.1.2)
+
+- A privacy policy URL must be set in App Store Connect AND accessible within the app
+- The privacy policy must accurately describe what data you collect, how you use it, and who you share it with
+- App Store privacy nutrition labels must match your actual data collection practices
+- Privacy labels, privacy manifests, SDK disclosures, and runtime behavior should tell the same story
+
+## In-App Purchase and StoreKit Rules (Guideline 3.1.1)
+
+IAP rules are strict and heavily enforced.
+
+### What Generally Requires Apple IAP
+
+Digital content, features, subscriptions, and services unlocked in the app generally must use Apple's In-App Purchase system unless a specific App Review guideline exception, regional rule, or approved entitlement applies. Remove external purchase paths unless the current rules or an approved entitlement allow them:
+
+- Premium features or content unlocks
+- Subscriptions to app functionality
+- Virtual currency, coins, gems
+- Ad removal
+- Digital tips or donations
+
+### What Does NOT Require IAP
+
+- Physical products (e-commerce)
+- Ride-sharing, food delivery, real-world services
+- One-to-one services (tutoring, consulting booked through the app)
+- Enterprise/B2B apps distributed through Apple Business Manager
+
+### Subscription Display Requirements
+
+- Price, duration, and auto-renewal terms must be clearly displayed before purchase
+- Free trials must clearly show trial duration, post-trial price, billing frequency, auto-renewal, and cancellation terms before purchase
+- Remove external purchase links, buttons, calls to action, or purchase paths for digital goods unless the current storefront rules or an approved entitlement explicitly allow them
+- "Reader" apps (Netflix, Spotify) may link to external sign-up but cannot offer IAP bypass
+
+### StoreKit Implementation Checklist
+
+- Consumables, non-consumables, and subscriptions must be correctly categorized in App Store Connect
+- Restore purchases functionality must be present and working
+- Transaction verification should use StoreKit 2 `Transaction.currentEntitlements` or server-side validation
+- Handle interrupted purchases, deferred transactions, and ask-to-buy gracefully
+
+## HIG Compliance Checklist
+
+See [references/review-checklists.md](references/review-checklists.md) for the full HIG checklist (navigation, modals, widgets, system feature support, launch screen, empty states). This section stays intentionally brief to keep SKILL.md concise.
+
+## App Tracking Transparency (ATT)
+
+### When ATT Is Required
+
+If your app tracks users across other companies' apps or websites, you must:
+
+1. Request permission via `ATTrackingManager.requestTrackingAuthorization` before any cross-app or cross-website tracking occurs, including tracking-capable SDK behavior
+2. Respect the user's choice -- disable cross-app and cross-website tracking if the user denies permission
+3. Not gate app functionality behind tracking consent ("Accept tracking or you cannot use this app" is rejected)
+4. Provide a clear purpose string in `NSUserTrackingUsageDescription` explaining what tracking is used for
+
+### When ATT Is NOT Required
+
+If you do not track users across apps or websites, do not show the ATT prompt. Apple rejects unnecessary ATT prompts.
+
+### ATT Implementation
+
+```swift
+import AppTrackingTransparency
+
+@MainActor
+func requestTrackingPermission() async {
+    let status = await ATTrackingManager.requestTrackingAuthorization()
+    switch status {
+    case .authorized:
+        // Enable tracking, initialize ad SDKs with tracking
+        break
+    case .denied, .restricted:
+        // Use non-personalized ads and disable cross-app/cross-website tracking
+        break
+    case .notDetermined:
+        // Should not happen after request, handle gracefully
+        break
+    @unknown default:
+        break
+    }
+}
+```
+
+**Timing:** Request ATT permission after the app is active and the user has context for why tracking is being requested. Do not show the prompt immediately on first launch or stack it with another system permission prompt.
+
+## EU Digital Markets Act (DMA) Considerations
+
+For apps distributed in the EU, and for other region-specific distribution models as Apple updates them:
+
+- Alternative browser engines are permitted on iOS in the EU
+- Alternative app marketplaces exist -- apps may be distributed outside the App Store
+- External payment links may be allowed under specific conditions, with Apple's commission structure adjusted
+- Notarization is required even for sideloaded apps distributed outside the App Store
+- Apps using alternative distribution must still meet Apple's notarization requirements for security
+
+## Entitlements and Capabilities
+
+Every entitlement must be justified. Apple reviews these closely:
+
+| Entitlement | Apple Scrutiny |
+|---|---|
+| Camera | Must explain purpose in `NSCameraUsageDescription` |
+| Location (Always) | Must have clear, user-visible reason for background location |
+| Push Notifications | Must not be used for marketing without user opt-in |
+| HealthKit | Must actually use health data in a meaningful way |
+| Background Modes | Each mode (audio, location, VoIP, fetch) must be justified and actively used |
+| App Groups | Must explain what shared data is needed |
+| Associated Domains | Universal links must actually resolve and function |
+
+### Usage Description Strings
+
+Usage descriptions in Info.plist must be specific about what data is accessed and why:
+
+```xml
+// REJECTED -- too vague
+
+// APPROVED -- specific purpose
+"Your location is used to show nearby restaurants on the map."
+
+// REJECTED -- too vague
+"This app needs access to your camera."
+
+// APPROVED -- specific purpose
+"The camera is used to scan barcodes for price comparison."
+```
+
+Apple rejects vague usage descriptions. Always state what the data is used for in user-facing terms.
+
+## Submission Workflow
+
+### Pre-Submission Steps
+
+1. **Archive in Xcode.** Product > Archive (requires a Distribution signing identity). Verify the archive builds clean with zero warnings in Release configuration.
+2. **Upload to App Store Connect.** Use the Organizer window (Distribute App > App Store Connect) or `xcodebuild -exportArchive`. Automated uploads via `altool` or Transporter also work.
+3. **TestFlight internal testing.** The build is available to internal testers (your team) within minutes of processing. Walk through every screen and flow on at least two device sizes.
+4. **TestFlight external testing.** External groups require Beta App Review before first external distribution. Use this to validate with real users before full submission.
+5. **Submit for App Review.** In App Store Connect, select the build, fill in all metadata fields, attach screenshots, and click Submit for Review. Review timing varies; allow buffer for rejections, appeals, and metadata fixes.
+
+### Expedited Review Requests
+
+Apple grants expedited reviews for critical situations only:
+
+- Critical bug fix affecting existing users
+- Time-sensitive event (holiday launch, legal compliance deadline)
+- Security vulnerability patch
+
+Request via the Contact Us form in App Store Connect (App Review > Expedite Request). Provide a specific, factual justification. Do not request expedited review for initial launches or feature updates.
+
+### Phased Release
+
+After approval, you can enable phased release to gradually roll out the update:
+
+| Day | Percentage of Users |
+|-----|---------------------|
+| 1   | 1%                  |
+| 2   | 2%                  |
+| 3   | 5%                  |
+| 4   | 10%                 |
+| 5   | 20%                 |
+| 6   | 50%                 |
+| 7   | 100%                |
+
+Users who manually check for updates in the App Store will receive the update immediately regardless of phased release stage. You can pause, resume, or complete the rollout at any time from App Store Connect.
+
+## Metadata Best Practices
+
+### App Name and Subtitle
+
+- **30 characters max** for the app name. Keep it memorable and unique.
+- **30 characters max** for the subtitle. Use it for a concise value proposition.
+- No generic terms that describe a category ("Photo Editor" alone is likely rejected).
+- No competitor names or trademarked terms you do not own.
+- No pricing information in the name or subtitle.
+- Name must be unique on the App Store -- Apple rejects duplicates.
+
+### Screenshot Requirements
+
+- Provide 1-10 screenshots per required platform and localization.
+- For iPhone, use the current App Store Connect screenshot specifications. As of May 2026, 6.9-inch iPhone screenshots are the primary accepted iPhone set; 6.5-inch screenshots are required only when 6.9-inch screenshots are not provided, and smaller iPhone displays can use scaled screenshots from larger sets.
+- For iPad apps, 13-inch iPad screenshots are required; smaller iPad displays can use scaled screenshots from larger sets.
+- Screenshots must show the **actual app UI** -- no misleading content, no features that do not exist.
+- Text overlays and marketing frames are allowed but must not obscure or misrepresent the actual interface.
+- Up to 10 screenshots per localization.
+- Screenshots for different localizations should show localized UI.
+
+### Keyword Field Compliance
+
+- 100-character limit, comma-separated, no spaces after commas.
+- Do not duplicate words already in your app name or subtitle (Apple indexes those automatically).
+- Use singular or plural, not both ("game" not "game,games").
+- No competitor names, trademarked terms, or irrelevant words.
+
+### App Preview Videos
+
+- **30 seconds max** per preview video.
+- Up to 3 preview videos per localization.
+- Must show the actual app running on device -- no pre-rendered animations of features that look different in practice.
+- App audio is captured; narration and background music are optional.
+- Avoid any framing, hand footage, or visual treatment that makes the preview misleading about the actual app experience.
+- First frame is used as the poster frame on the product page (choose carefully).
+
+## Appeal Process
+
+### Replying to Rejections
+
+All rejections appear in the **Resolution Center** in App Store Connect. To respond:
+
+1. Read the rejection message carefully -- it cites the specific guideline violated.
+2. Reply directly in the Resolution Center thread with a clear, factual explanation.
+3. If you made a fix, describe exactly what changed and resubmit the binary.
+4. If you believe the rejection is incorrect, explain why your app complies, with references to the specific guideline text.
+
+**Tone matters.** Be professional, specific, and concise. Provide demo credentials, screenshots, or screen recordings that demonstrate compliance. Avoid emotional language or threats.
+
+### Escalation to App Review Board
+
+If the Resolution Center exchange does not resolve the issue:
+
+1. Request an appeal to the **App Review Board** via the Resolution Center or the App Store Contact form (App Review > Appeal).
+2. The Board is a separate team from the original reviewer. Provide all context -- they review the full history.
+3. Board decisions are final for that submission, but you can always modify the app and resubmit.
+
+### Common Successful Appeal Strategies
+
+- **Provide a video walkthrough** showing the feature the reviewer could not find or access.
+- **Cite the specific guideline** and explain how the app satisfies each requirement.
+- **Include demo credentials** if the reviewer could not log in (the most common 2.1 rejection cause).
+- **Reference precedent** -- if similar apps exist on the App Store with the same pattern, note them (respectfully).
+- **Offer a compromise** -- if Apple objects to a specific implementation, propose an alternative that satisfies both sides.
+
+## Common Mistakes
+
+1. **Missing demo credentials.** Provide App Review login credentials in App Store Connect notes. Most Guideline 2.1 rejections are from reviewers unable to test behind a login.
+2. **Privacy manifest mismatch.** Declared data collection in PrivacyInfo.xcprivacy must match App Store privacy nutrition labels, SDK behavior, and app functionality.
+3. **Unnecessary ATT prompt.** Do not show the App Tracking Transparency prompt unless you actually track users across apps or websites. Apple rejects unnecessary prompts.
+4. **Vague usage descriptions.** "This app needs your location" is rejected. State the specific feature that uses the data.
+5. **Unapproved external purchase paths.** External payment links for digital goods are region- and entitlement-sensitive; do not add them without checking current Guideline 3.1.1(a) rules.
+6. **Treating code quality as review compliance.** Swift 6 concurrency annotations and StoreKit transaction handling matter, but they do not replace privacy, payment, metadata, and entitlement compliance checks.
+
+## Review Checklist
+
+Quick-check before every submission (full version in [references/review-checklists.md](references/review-checklists.md)):
+
+- [ ] No placeholder/test content; all features functional; demo credentials provided
+- [ ] App name matches functionality; screenshots are real; no prices in description; 6.9-inch iPhone and 13-inch iPad screenshots supplied when applicable
+- [ ] PrivacyInfo.xcprivacy present when required-reason APIs, tracking, collected data declarations, or SDK tracking domains apply; nutrition labels match reality
+- [ ] Privacy policy URL set and accessible in-app
+- [ ] Digital content uses IAP; subscription terms visible; restore purchases works; external purchase links/buttons/CTAs removed unless current rules or approved entitlements allow them
+- [ ] Dark Mode and Dynamic Type supported; standard navigation patterns
+- [ ] Built with Xcode 26+ and platform SDK 26+ for uploads after April 28, 2026; no private APIs; entitlements justified
+- [ ] ATT prompt only if cross-app or cross-website tracking occurs
+- [ ] Every interactive element has a handler; smoke-tested on a physical iPad in a release build
+- [ ] Purchase in sandbox unlocks the entitlement without an app restart; Paid Applications Agreement is `Active`
+- [ ] Build number higher than the last uploaded build; the fix commit is an ancestor of the submitted build's revision
+
+## References
+
+- Review checklists: [references/review-checklists.md](references/review-checklists.md)
+- Privacy manifest guide: [references/privacy-manifest.md](references/privacy-manifest.md)
+- Field lessons (React Native / Expo / EAS / RevenueCat): [references/field-lessons-rn-expo.md](references/field-lessons-rn-expo.md)
+- Apple App Review Guidelines: https://developer.apple.com/app-store/review/guidelines/
+- Apple upcoming SDK requirements: https://developer.apple.com/news/upcoming-requirements/
+- App Store Connect screenshot specifications: https://developer.apple.com/help/app-store-connect/reference/app-information/screenshot-specifications/
+- Sosumi required-reason API docs: https://sosumi.ai/documentation/bundleresources/describing-use-of-required-reason-api

--- a/plugins/app-store-review/evals/evals.json
+++ b/plugins/app-store-review/evals/evals.json
@@ -1,0 +1,85 @@
+{
+  "skill_name": "app-store-review",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Audit this iOS app's App Store submission readiness: it has subscriptions, a third-party analytics SDK, ads that may track users across apps, iPhone and iPad support, and a PrivacyInfo.xcprivacy file that only declares UserDefaults with CA92.1. Give the highest-risk rejection issues and the exact checks the team should run before upload.",
+      "expected_output": "A source-grounded App Review readiness audit covering IAP/subscription display, ATT, privacy manifests and SDK manifests, Xcode/SDK upload requirements, screenshot requirements, metadata, and reviewer access.",
+      "files": [],
+      "expectations": [
+        "Mentions that uploads after April 28, 2026 need Xcode 26 or later with the relevant platform SDK 26 or later.",
+        "Identifies that tracking across apps or websites requires ATT, NSUserTrackingUsageDescription, and no tracking before authorization.",
+        "Checks whether third-party SDK code that collects data, uses required-reason APIs, enables data collection, or contacts tracking domains has its own privacy manifest.",
+        "Warns that digital subscriptions generally require StoreKit IAP and visible subscription terms, restore purchases, and no external purchase path unless current rules or entitlements allow it.",
+        "Includes iPhone 6.9-inch and iPad 13-inch screenshot requirements for a universal iPhone/iPad app."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Review this proposed PrivacyInfo.xcprivacy plan: the app uses UserDefaults for settings, checks free disk space before downloading offline videos, reads file modification dates for files picked through UIDocumentPickerViewController, and includes an SDK that wraps UserDefaults for the app. Which required-reason API categories and reason codes should be declared, and where should the app versus SDK declarations live?",
+      "expected_output": "A privacy-manifest reason-code review that selects current approved reason codes and correctly separates app manifest declarations from SDK manifest declarations.",
+      "files": [],
+      "expectations": [
+        "Selects NSPrivacyAccessedAPICategoryUserDefaults with CA92.1 for app-owned UserDefaults settings.",
+        "Selects NSPrivacyAccessedAPICategoryDiskSpace with E174.1 for checking free space before downloads.",
+        "Selects NSPrivacyAccessedAPICategoryFileTimestamp with 3B52.1 for user-granted document picker files.",
+        "Selects UserDefaults wrapper SDK reason C56D.1 for the SDK only and says the SDK must report its own required-reason API use in its own manifest.",
+        "Warns not to invent broad reasons and to re-check Apple's current required-reason API documentation."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I want better App Store keywords and screenshot captions for my habit tracker, but I also don't want a metadata rejection. Give me the compliance guardrails only, and call out which parts belong in an ASO strategy pass rather than an App Review pass.",
+      "expected_output": "A boundary-aware answer that keeps app-store-review focused on metadata compliance and routes keyword strategy and conversion optimization to the ASO skill.",
+      "files": [],
+      "expectations": [
+        "States that keyword research, ranking strategy, and conversion optimization belong to an ASO strategy pass rather than App Review compliance.",
+        "Gives App Review metadata guardrails: accurate app name, screenshots showing real UI, no misleading features, no prices in description, no competitor names or irrelevant keywords.",
+        "Mentions the 30-character app name/subtitle limits and 100-character keyword field limit with comma-separated keywords and no spaces after commas.",
+        "Mentions current screenshot size compliance, including 6.9-inch iPhone and 13-inch iPad requirements when applicable.",
+        "Does not expand into a full keyword plan or marketing copy rewrite."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Apple rejected our React Native app under Guideline 2.1(b): 'the premium content remained locked after purchase' in the sandbox on iPad. We use RevenueCat, and our purchase flow calls a backend webhook to validate before granting the entitlement. Our unit tests pass and the purchase itself succeeds. What is the root cause and how do we fix it?",
+      "expected_output": "A root-cause diagnosis identifying the webhook race in sandbox, with a fix that refreshes the provider cache, retries with backoff, and falls back to local customer info, plus the environment gates and the anti-fraud trade-off.",
+      "files": [],
+      "expectations": [
+        "Identifies that the server-side webhook frequently has not processed the sandbox transaction when the app queries, so entitlementGranted is false and the app locks premium.",
+        "Recommends invalidating the provider customer-info cache and reading fresh customer info before falling back to the backend.",
+        "Recommends retry with backoff and a fallback to the local RevenueCat/StoreKit customer info, which already has the entitlement active immediately after purchase.",
+        "States the anti-fraud trade-off explicitly and that the backend keeps validating asynchronously and can revoke.",
+        "Requires the entitlement grant to re-render the UI without an app restart.",
+        "Checks the Paid Applications Agreement is Active and that testing happens in sandbox on a physical iPad rather than the simulator."
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Apple rejected us under 2.1(a) saying the 'Rate app' and 'Delete account' buttons did nothing when tapped on an iPad Air. Both work when I test on my iPhone simulator. What should I check and what gates should I add so this never happens again?",
+      "expected_output": "A diagnosis covering the missing-handler pattern, the silent no-op native review prompt, and the nested-confirmation race on iPad, plus greppable pre-submission gates.",
+      "files": [],
+      "expectations": [
+        "Checks whether the element has accessibilityRole=\"button\" but no onPress handler, and provides a grep-style gate to detect interactive elements missing a handler.",
+        "Explains that the native review prompt is a silent no-op in App Review builds and rate-limited, so a fallback to the App Store product page URL is mandatory.",
+        "Identifies nested confirmation sheets racing the first sheet's dismissal as a likely iPad-specific cause and recommends one confirmation at a time.",
+        "States that iPad is commonly the review device and that testing must happen on a physical iPad in a release or TestFlight build, not an iPhone simulator.",
+        "Recommends reproducing the bug on iPad before applying the fix rather than assuming the root cause."
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "We are resubmitting an Expo/EAS app after a rejection. The fix is merged to main, EAS reports the build as finished, and I am about to hit Update Review. What should I verify first?",
+      "expected_output": "A submission-pipeline audit distinguishing the four states, verifying the build contains the fix, checking build number monotonicity and lockfile sync, and stopping for owner confirmation.",
+      "files": [],
+      "expectations": [
+        "Distinguishes the four states: cloud build finished, submit processed, build attached to the App Store version, and Update Review submitted.",
+        "Verifies the fix commit is an ancestor of the submitted build's revision, since a fix on main proves nothing about the binary Apple tested.",
+        "Verifies the build number is higher than the last uploaded build via the App Store Connect API, since build numbers are monotonic and single-use.",
+        "Checks the lockfile is in sync and regenerated on the CI Node major, since npm ci fails hard on drift.",
+        "Requires re-auditing screenshots when the reviewed UI changed, and auditing every locale and device slot via View All Sizes in Media Manager.",
+        "Stops before Update Review and requires explicit confirmation from the account owner."
+      ]
+    }
+  ]
+}

--- a/plugins/app-store-review/plugin.json
+++ b/plugins/app-store-review/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "app-store-review",
+  "version": "1.0.0",
+  "description": "Prepare for Apple App Store review and prevent rejections across native and React Native/Expo/EAS apps. Covers review guidelines, PrivacyInfo.xcprivacy, IAP and StoreKit, ATT, metadata, screenshots, App Store Connect pipeline gates, RevenueCat entitlement races, and field-tested rejection patterns.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "license": "MIT",
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "app-store-review",
+    "app-store",
+    "apple",
+    "ios",
+    "react-native",
+    "expo",
+    "eas",
+    "revenuecat",
+    "iap",
+    "privacy",
+    "metadata",
+    "app-review-rejections"
+  ]
+}

--- a/plugins/app-store-review/references/field-lessons-rn-expo.md
+++ b/plugins/app-store-review/references/field-lessons-rn-expo.md
@@ -1,0 +1,378 @@
+# Field Lessons — React Native / Expo / EAS App Store Rejections
+
+Rejection patterns observed across five consecutive App Review cycles on a production React Native + Expo + EAS + RevenueCat app (July–August 2026). Every entry below is a rejection that actually happened, its confirmed root cause, and the gate that prevents it. Use this alongside `review-checklists.md`; this file covers what the generic Apple guidance does not: the cross-stack failure modes specific to RN/Expo/EAS/RevenueCat submissions.
+
+## Contents
+
+- [Rejection Timeline](#rejection-timeline)
+- [2.1(a) — Dead Interactive Elements](#21a--dead-interactive-elements)
+- [2.1(a) — Login Loop from Auth Listener Null-Flash](#21a--login-loop-from-auth-listener-null-flash)
+- [2.1(b) — Entitlement Locked After Sandbox Purchase](#21b--entitlement-locked-after-sandbox-purchase)
+- [3.1.2(c) — Subscription Price Hierarchy](#312c--subscription-price-hierarchy)
+- [3.1.1 — Non-IAP Digital Currency Paths](#311--non-iap-digital-currency-paths)
+- [2.3.2 — Duplicate IAP Metadata and Promo Images](#232--duplicate-iap-metadata-and-promo-images)
+- [2.3.6 — Age Rating Declares Features That Do Not Exist](#236--age-rating-declares-features-that-do-not-exist)
+- [2.3.10 / 2.3.3 — Screenshots](#2310--233--screenshots)
+- [5.1.1(iv) — Pre-Permission Button Copy](#511iv--pre-permission-button-copy)
+- [5.1.1(ix) — Individual vs Organization Enrollment](#511ix--individual-vs-organization-enrollment)
+- [4.8 — Login Services Equivalence](#48--login-services-equivalence)
+- [1.5 — Support URL Must Actually Support](#15--support-url-must-actually-support)
+- [3.1.2 — Terms of Use / EULA Link](#312--terms-of-use--eula-link)
+- [Build, Version, and Submission Pipeline](#build-version-and-submission-pipeline)
+- [iPad Is the Review Device](#ipad-is-the-review-device)
+- [App Store Connect API — What It Can and Cannot Do](#app-store-connect-api--what-it-can-and-cannot-do)
+- [Pre-Submission Gate Script](#pre-submission-gate-script)
+
+---
+
+## Rejection Timeline
+
+Five cycles on one app. The pattern to internalize: **each fix surfaced the next layer of issues.** Assume at least two more rounds after any fix, and front-load the full checklist rather than fixing only what the reviewer cited.
+
+| Date | Guidelines cited | Theme |
+|---|---|---|
+| Jul 15, 2026 | 2.3.10, 4.8, 2.1(a) | Screenshots with non-iOS status bars; no Sign in with Apple; login loop |
+| Jul 21, 2026 | 2.1(b), 5.1.1(ix), 3.1.1, 2.3.6, 1.5 | Business model questions; individual account; non-IAP currency; age rating; dead support URL |
+| Jul 25, 2026 | 2.1(a), 2.3.3 | Login loop persisted (reviewed build predated the fix); iPad screenshots were mockups |
+| Aug 18, 2026 | 2.3.2 ×2, 2.3.6, 3.1.2(c), 2.1(b), 2.1(a), 5.1.1(iv) | Duplicate IAP metadata; price hierarchy; entitlement locked; dead buttons; permission copy |
+
+**Meta-lesson:** the same guideline was cited across cycles for *different* root causes (2.1(a) was first an auth bug, later a missing `onPress`). Never assume a repeat citation means the previous fix regressed — re-diagnose from scratch.
+
+---
+
+## 2.1(a) — Dead Interactive Elements
+
+**What happened:** a `TouchableOpacity` had `accessibilityRole="button"` and full styling but **no `onPress`**. The reviewer tapped "Rate app" on iPad; nothing happened. Instant 2.1(a).
+
+```tsx
+// REJECTED — signals interactive to VoiceOver and to the reviewer, does nothing
+<TouchableOpacity style={styles.menuButton} accessibilityRole="button">
+  <Text>{t("settings.support.rateApp")}</Text>
+</TouchableOpacity>
+```
+
+**Gate — run before every submission:**
+
+```bash
+rg -n "TouchableOpacity|Pressable" src --glob '*.tsx' -A6 \
+  | rg -B6 "accessibilityRole" | rg -v "onPress"
+# expect: no results
+```
+
+**Related trap — native review prompt is a silent no-op.** `StoreReview.requestReview()` (Expo) / `SKStoreReviewController` does nothing in App Review builds, and is rate-limited to ~3 prompts per year per user. A "Rate app" button wired only to the native prompt still reads as broken to the reviewer. **Always fall back to the App Store product page:**
+
+```ts
+if (await StoreReview.hasAction()) {
+  await StoreReview.requestReview();       // may be a silent no-op
+} else {
+  await Linking.openURL(`https://apps.apple.com/app/id${APP_ID}?action=write-review`);
+}
+```
+
+Treat "nothing visible happened" as a failing state: surface a snackbar rather than returning silently.
+
+**Related trap — nested confirmation sheets race on iPad.** Two chained `confirmAction()` calls (second fired inside the first's `onConfirm`) raced against the first sheet's dismissal animation. On iPhone it worked; on iPad's larger layout and different animation timing, the second sheet never rendered — "Delete account" appeared dead. Use one confirmation at a time (explicit step state, or a single sheet with the irreversible copy inline). Apple does not require double confirmation — only that deletion *works*.
+
+---
+
+## 2.1(a) — Login Loop from Auth Listener Null-Flash
+
+**What happened:** "we were unable to login as the app kept bringing us back to the login screen." Reproduced on iPad, in release builds only.
+
+**Root cause:** during `signInWithCredential`, native Firebase Auth emits a **transient `onAuthStateChanged(null)`** followed by the real user event. In release builds the JS bridge batches differently: the recovery event arrived *while* the store was still ignoring events (`loading === true`) and was discarded, then the stale null arrived *after* `loading = false` and destroyed the freshly-created session. No error, no crash — the user just bounced back to login. A cold start restored the session from the keychain, which is why it looked unreproducible locally.
+
+**Fix — two independent layers:**
+
+1. **Repository layer:** a null auth event is re-checked against `getAuth().currentUser` with progressive delays (e.g. 250 + 300 + 300 ms). If the native side already recovered a user, the null is *dropped* and never reaches consumers.
+2. **Store layer:** a late null arriving while a session is established triggers a revalidation via `getCurrentUser()` before clearing. User present = null-flash, keep the session. User absent = real sign-out, clear. Revalidation failure = keep the session (safe default).
+
+**Generalize:** never apply `user: null` from an auth event without either a settle window at the SDK boundary or a revalidation against the native source. "Ignore events while loading" guards are necessary but never sufficient — native event delivery has no ordering guarantee relative to JS promises.
+
+**Related trap — logout must not disable the next login.** Sign-out that tears down the auth listener lifecycle leaves the following `signIn()` with nothing to publish the user. Keep the listener alive after explicit logout; reserve full lifecycle teardown for app shutdown.
+
+**Related trap — offline is not signed-out.** A Firestore `client is offline` error is a read/network failure, not proof the user is logged out. Preserve the known session, classify the error, offer recovery.
+
+**Gate:** test cold start, reload with a persisted session, logout, user switch, transient network loss and recovery — on **both** iPhone and iPad, in a **release/TestFlight build**, not a dev build.
+
+---
+
+## 2.1(b) — Entitlement Locked After Sandbox Purchase
+
+**What happened:** "the premium content remained locked after purchase" in the sandbox on iPad. Confirmed architectural root cause, not a flake.
+
+**Root cause:** the purchase flow validated against a server-side webhook and treated `entitlementGranted === false` as `"pending"` with no retry and no local fallback. In sandbox the RevenueCat/StoreKit webhook frequently has not processed the transaction when the app asks — so the app locked premium permanently while the **local `customerInfo` already had the entitlement active**.
+
+```ts
+// REJECTED — no refresh, no retry, no local fallback
+async syncEntitlements(userId: string) {
+  return this.fetchEntitlement(userId);   // reads backend only
+}
+
+// CORRECT — invalidate cache, read fresh customerInfo, fall back to backend
+async syncEntitlements(userId: string) {
+  await Purchases.invalidateCustomerInfoCache();
+  const info = await Purchases.getCustomerInfo();
+  const active = info.entitlements.active[PREMIUM_ENTITLEMENT_ID];
+  if (active) return mapCustomerInfoToEntitlement(userId, active, info);
+  return this.fetchEntitlement(userId);
+}
+```
+
+Plus, in the purchase use case: when validation succeeds but the entitlement is not yet granted, retry `syncEntitlements` with backoff (e.g. 500 / 1500 / 3000 ms) and, if still empty, grant from the local `customerInfo`. The RevenueCat SDK knows the entitlement the instant the purchase completes; depending solely on the webhook is what produces "premium remained locked."
+
+**Trade-off to state explicitly in the PR:** granting from local `customerInfo` weakens the anti-fraud barrier. Mitigation: the backend continues validating asynchronously and can revoke. This is an optimistic-UX decision that satisfies 2.1(b) — get the account owner's sign-off rather than making it silently.
+
+**UI gate:** after the entitlement is granted, the paywall must close or flip to "already premium" **without an app restart**. Audit every entitlement consumer for reactive re-render.
+
+**Environment gates that block IAP entirely:**
+- **Paid Applications Agreement must be `Active`** (Agreements, Tax, and Banking). Pending banking or tax = no purchase works for anyone, including the reviewer.
+- Sandbox testers exist and are signed in under **Settings → App Store → Sandbox Account** (not the main Apple ID).
+- Test on a **physical iPad**. The simulator does not reproduce sandbox IAP behavior faithfully.
+
+---
+
+## 3.1.2(c) — Subscription Price Hierarchy
+
+**What happened:** the paywall rendered the calculated per-month figure ("R$ 8,33/mês") at the same visual weight as the amount actually billed ("R$ 99,90/ano"). Apple requires the **billed amount to be clear and conspicuous**, with everything else subordinate in size *and* position.
+
+**Required hierarchy inside the plan card:**
+
+```
+┌─────────────────────────────────┐
+│  Annual                         │  plan name
+│  $99.90 / year                  │  BILLED AMOUNT — largest, highest contrast
+│  equivalent to $8.33/month      │  calculated — smaller, muted
+│  Renews automatically           │  disclosure
+└─────────────────────────────────┘
+```
+
+The billed amount must be the largest typographic element in the card. No badge ("Best value", "Save 40%") may compete with it in size or contrast.
+
+**Related trap — hardcoded derived prices.** The per-month string was a fixed literal in the locale file rather than derived from `product.price / 12`. Any price tier or storefront change makes it a lie — a future 2.3.2 on its own. Always compute the equivalent from the live product price, respecting the product's currency and locale.
+
+**Also required before purchase:** duration, billing frequency, auto-renewal terms, and for trials the trial length, post-trial price, and cancellation terms.
+
+---
+
+## 3.1.1 — Non-IAP Digital Currency Paths
+
+**What happened:** "The Sport Coins can be purchased in the app using payment mechanisms other than In-App Purchase."
+
+**Root cause:** a legacy wallet flow that called a local credit path after an external checkout, letting balance be credited without server-side confirmation.
+
+**Fix pattern:**
+1. Remove every external purchase path, link, button, and CTA for digital goods from the iOS build — not just the button, but the routes, deep links, offering loads, and shortcuts.
+2. Make the server webhook the **only** origin of credit ledger entries, with an idempotent transaction keyed on the provider `event.id`.
+3. Block client-side creation of purchase-credit entries in Firestore/backend security rules.
+4. Where a feature cannot be made compliant in time, gate it off for iOS via a remote config flag with an OS-name condition — and verify the tab, menu entries, home CTAs, routes, **and deep links** all redirect, not just the visible entry point.
+
+**Verification:** confirm the gated surface is unreachable via deep link and that no offering for the removed SKUs is loaded on iOS.
+
+**Note (5.3.3):** IAP may not be used to buy credit or currency used for real-money gaming. If the product looks like that to Apple, no amount of StoreKit correctness fixes it.
+
+---
+
+## 2.3.2 — Duplicate IAP Metadata and Promo Images
+
+Two distinct rejections from the same guideline in one cycle:
+
+1. **Identical display name + description** across the monthly and annual subscriptions. Each product must be unique **within each locale** — differing in PT while EN and ES stay identical still fails.
+   - Hard limits: display name **30 characters**, description **45 characters**.
+2. **The same promotional image** uploaded for two promoted IAPs.
+   - Cheapest fix, offered by Apple in the rejection text itself: if you have no plans to promote the IAP, **delete the promotional image**.
+   - If promoting: 1024×1024 PNG/JPG, no transparency, no rounded corners, and **visually distinct** per product — swapping one word is not enough.
+
+**Gate:** enumerate every product × locale combination and diff them pairwise before submitting.
+
+---
+
+## 2.3.6 — Age Rating Declares Features That Do Not Exist
+
+**What happened:** the Age Rating declared *In-App Controls*, but the reviewer found neither Parental Controls nor an Age Assurance mechanism.
+
+Age rating answers are metadata claims. If you declare a control, the reviewer must be able to **find and operate it**. Either set the declaration to `None`, or reply with the precise navigation path to the feature (screen, action, and the exact gate it enforces).
+
+This one cost two cycles: the first response argued the feature existed via a video-age-gate sheet; the reviewer still could not locate it. When a declaration is defensible only via a written explanation, prefer setting it to `None` unless the feature is genuinely front-and-center.
+
+---
+
+## 2.3.10 / 2.3.3 — Screenshots
+
+Two separate rejections, both about screenshots:
+
+- **2.3.10:** screenshots contained **non-iOS status bars** (Android frames / third-party mockup templates).
+- **2.3.3:** iPad 13-inch screenshots were **marketing mockups**, not the app in use. Apple requires the majority of screenshots to highlight the app's actual main features.
+
+**Rules learned:**
+
+- Capture from the **candidate iOS build itself**. Never mockups, never promotional renders, never Android frames or third-party device chrome.
+- The binary's language does **not** select the metadata language. Upload is per App Store Connect locale — English assets to `English (U.S.)`, Portuguese to `Portuguese (Brazil)`, and so on.
+- Every device family, size, and orientation is an **independent slot set**. Use **View All Sizes in Media Manager** and scroll each tab to the end. The default preview hides slots that still hold old assets.
+- Record file, locale, device slot, dimensions, and visual confirmation for each upload. Do not declare "screenshots fixed" while any stale slot remains.
+- Dimensions accepted in practice for this app: iPhone 6.9" — `1320×2868` (also `1284×2778`, `1242×2688`, `2688×1242`, `2778×1284`); iPad 13" — `2064×2752` or `2048×2732`; iPad 11" — `1668×2388`. Always confirm against the slot App Store Connect displays.
+- Re-capture screenshots whenever the reviewed UI changed. Shipping a paywall fix while the store still shows the old paywall invites a fresh 2.3.2.
+
+---
+
+## 5.1.1(iv) — Pre-Permission Button Copy
+
+**What happened:** the custom pre-permission screen before the camera prompt had a button labeled "Grant Permission" / "Conceder Permissão". Apple's instruction was literal: *"Use words like 'Continue' or 'Next' on the button instead."*
+
+A pre-permission screen may explain **why** you need access, but its button must not imply it grants the permission — only the system prompt does that. Change the visible label **and** the `accessibilityLabel` (reviewers use VoiceOver).
+
+The recovery branch (permission already denied, `!canAskAgain`) may still say "Open Settings" — that is not a pre-permission button.
+
+**Gate:**
+
+```bash
+rg -n "Grant Permission|Conceder Permissão|Otorgar Permiso" src/
+# expect: no results
+```
+
+Apply the same rule to every permission pre-prompt: camera, photos, notifications, location, contacts, microphone.
+
+---
+
+## 5.1.1(ix) — Individual vs Organization Enrollment
+
+**What happened:** Apple classified the app as offering highly regulated services / handling sensitive user data and required the submitting account to be enrolled as an **organization**, not an individual.
+
+This is not fixable in code. There is no documentation workaround — Apple states explicitly that permission letters do not resolve it. Options: enroll a new organization account, or request conversion of the individual account through Apple Developer Support.
+
+**Front-load this check.** If the app touches finance, wagering, health, or similarly regulated territory, resolve enrollment before spending cycles on code fixes — every other fix is blocked behind it.
+
+---
+
+## 4.8 — Login Services Equivalence
+
+**What happened:** the app offered third-party login (Google) without an equivalent option that limits collection to name and email, lets the user keep the email private, and does not collect in-app interactions for advertising without consent.
+
+**Fix:** add Sign in with Apple, which satisfies all three by definition.
+
+**Implementation traps specific to RN/Firebase:**
+- Generate a **fresh nonce per attempt**; reuse fails credential exchange.
+- Handle **silent cancellation** — the user dismissing the sheet must not surface as an error state or leave a spinner.
+- Apple returns the display name **only on first authorization**. Persist it then; never overwrite a stored name with a later empty value.
+- `@privaterelay.appleid.com` addresses are valid — do not treat them as malformed or reject them in validation.
+- Verify Hide My Email / Private Relay end-to-end on a real device.
+
+---
+
+## 1.5 — Support URL Must Actually Support
+
+**What happened:** the Support URL pointed to an anchor (`/#faq`) that did not render a functional support section.
+
+The URL must resolve to a page where a user can genuinely ask a question — a contact address, a form, or documented support instructions. Verify the deployed public page, including the anchor, before pasting it into App Store Connect. Deploy the site *before* submitting; a URL that will be live "soon" fails review.
+
+---
+
+## 3.1.2 — Terms of Use / EULA Link
+
+Auto-renewable subscriptions require a **functional Terms of Use (EULA) link in the app's metadata**. Configure all three:
+
+1. **App Information → EULA** — custom EULA URL or full text.
+2. **App Description** — Terms + Privacy links in **every** locale.
+3. **Subscription → Terms of Use URL** — per subscription in the group.
+
+```bash
+curl -sS -o /dev/null -w "terms: %{http_code}\n"   -L https://example.com/terms
+curl -sS -o /dev/null -w "privacy: %{http_code}\n" -L https://example.com/privacy
+# both must be 200
+```
+
+**Latent risk:** 3.1.2 also expects the user to reach Terms/Privacy **inside the app** before subscribing. Metadata links satisfy the metadata rejection; a Settings → Terms/Privacy screen with `Linking.openURL` closes the in-app gap before it becomes the next rejection.
+
+---
+
+## Build, Version, and Submission Pipeline
+
+**Four distinct states, routinely conflated.** "EAS build finished" ≠ "submit processed" ≠ "build attached to the App Store version" ≠ "Update Review submitted". Verify each one independently; a green EAS status proves only the first.
+
+**Build numbers are monotonic and single-use.** Reusing one fails upload with `bundle version must be higher than previously uploaded version`. Confirm the last accepted build via the App Store Connect API before submitting:
+
+```bash
+curl -s -H "Authorization: Bearer $ASC_JWT" \
+  "https://api.appstoreconnect.apple.com/v1/builds?filter[app]=$APP_ID&sort=-uploadedDate&limit=5" \
+  | jq '.data[] | {version: .attributes.version, state: .attributes.processingState}'
+```
+
+`package.json` version is the marketing version; the build number is the Apple-facing monotonic counter. With EAS `appVersionSource: remote` + `autoIncrement: true`, the **remote counter is the authority** — not any local file.
+
+**Lockfile must be in sync, generated on the CI Node major.** EAS runs `npm ci`, which fails hard on any `package.json` / `package-lock.json` drift. Regenerate the lock with the same Node major the build profile pins, and commit both files together, before the cloud build.
+
+**Verify the reviewed build actually contains the fix.** One rejection repeated purely because the reviewed build predated the fix commit. Before responding to a reviewer, confirm the fix commit is an ancestor of the submitted build's revision — a fix on `main` proves nothing about the binary Apple tested.
+
+**Stop before `Update Review`.** Submitting is outward-facing and irreversible in effect. Get explicit confirmation from the account owner. Same for replying to the reviewer and releasing.
+
+**A rejected submission can be withdrawn to unblock metadata edits.** IAP localization `PATCH` calls returned `409 UNMODIFIABLE` while the version sat in `WAITING_FOR_REVIEW`. Using "Remove from Review" in App Store Connect moved it to `DEVELOPER_REJECTED` → `PREPARE_FOR_SUBMISSION`, which unblocked editing **without destroying** the attached build, screenshots, or linked IAPs.
+
+---
+
+## iPad Is the Review Device
+
+Every rejection in this timeline was found on an **iPad Air 11-inch (M3)**. Reviewers commonly use iPad for universal apps, and several bugs reproduced **only** there:
+
+- Nested confirmation sheets racing (different animation timing / layout).
+- The auth null-flash surfacing under release-build event batching.
+
+**Gate:** run the full smoke test on a physical iPad in a release/TestFlight build before every submission — login (each provider), session persistence across cold start, purchase, and every Settings action. iPhone-only testing is not coverage.
+
+---
+
+## App Store Connect API — What It Can and Cannot Do
+
+| Action | API? | Note |
+|---|---|---|
+| Read submission state, builds, IAPs, age rating | Yes | Read-only queries are safe to automate |
+| Age Rating declaration | `PATCH /v1/ageRatingDeclarations/{id}` | Confirm with the owner first |
+| IAP / subscription display name and description | `PATCH /v1/inAppPurchaseLocalizations/{id}` | 30 / 45 char limits |
+| Delete a promo image | `DELETE /v1/promotedPurchaseImages/{id}` | Simpler than authoring two unique images |
+| Upload a promo image | Three-step (reserve → upload → commit) | Painful; the App Store Connect UI is faster |
+| Upload App Store screenshots | Technically yes | Recommended: do it manually |
+| **Create sandbox testers** | **No** | `/v1/sandboxTesters` returns `404 PATH_ERROR`; UI only |
+| Submit for review | Yes | **Do not run without explicit owner confirmation** |
+
+**Credential hygiene:** the `.p8` private key, issuer ID, and key ID live outside the repo (e.g. `~/.config/asc/`), are `.gitignore`d (`*.p8`, `AuthKey_*.p8`, `credentials.env`), and JWTs (20-minute lifetime) are never logged in plaintext or committed. Use the minimum API key role for the task. On leak: revoke in App Store Connect, recreate, rotate.
+
+---
+
+## Pre-Submission Gate Script
+
+Run all of these green before building the submission candidate.
+
+```bash
+# Dead interactive elements (2.1(a))
+rg -n "TouchableOpacity|Pressable" src --glob '*.tsx' -A6 \
+  | rg -B6 "accessibilityRole" | rg -v "onPress"
+
+# Pre-permission button copy (5.1.1(iv))
+rg -n "Grant Permission|Conceder Permissão|Otorgar Permiso" src/
+
+# Native alerts instead of in-app confirmation UI (review-flow reliability)
+rg -n "Alert\.(alert|prompt)" src/
+
+# Terms / privacy reachable
+curl -sS -o /dev/null -w "terms: %{http_code}\n"   -L "$TERMS_URL"
+curl -sS -o /dev/null -w "privacy: %{http_code}\n" -L "$PRIVACY_URL"
+curl -sS -o /dev/null -w "support: %{http_code}\n" -L "$SUPPORT_URL"
+
+# Build hygiene
+npm run validate:lockfile     # package.json / package-lock.json in sync on the CI Node major
+tsc --noEmit                  # zero errors
+npx vitest run                # suite green
+```
+
+**Manual gates that no script covers:**
+
+- [ ] Physical iPad, release/TestFlight build: login with **every** provider, session survives cold start
+- [ ] Physical iPad sandbox: monthly **and** annual purchase each unlock premium **without restart**
+- [ ] Paid Applications Agreement is `Active`
+- [ ] Every Settings action does something visible (rate, delete account, logout, support)
+- [ ] Billed amount is the largest element in each plan card
+- [ ] IAP display names and descriptions unique per product **per locale**
+- [ ] Promo images deleted or visually distinct per product
+- [ ] Age Rating claims only features a reviewer can find and operate
+- [ ] Screenshots captured from the candidate build, audited slot-by-slot in **View All Sizes in Media Manager**, all locales
+- [ ] Build number is higher than the last uploaded build (verified via API)
+- [ ] The fix commit is an ancestor of the submitted build's revision
+- [ ] Reviewer response drafted; **stop and get owner confirmation before `Update Review`**

--- a/plugins/app-store-review/references/privacy-manifest.md
+++ b/plugins/app-store-review/references/privacy-manifest.md
@@ -1,0 +1,113 @@
+# Privacy Manifest Reference
+
+## Contents
+- When a Privacy Manifest Is Required
+- Privacy Manifest Structure
+- Required API Reason Codes
+- Privacy Manifest Keys Reference
+- Third-Party SDK Manifests
+- Collected Data Types Declaration
+- Sources To Re-Check
+
+## When a Privacy Manifest Is Required
+
+A `PrivacyInfo.xcprivacy` file is required if your app or any dependency uses these API categories:
+
+- File timestamp APIs (`NSPrivacyAccessedAPICategoryFileTimestamp`)
+- System boot time APIs (`NSPrivacyAccessedAPICategorySystemBootTime`)
+- Disk space APIs (`NSPrivacyAccessedAPICategoryDiskSpace`)
+- User defaults (`NSPrivacyAccessedAPICategoryUserDefaults`)
+- Active keyboard APIs (`NSPrivacyAccessedAPICategoryActiveKeyboards`)
+
+Apple updates required-reason API coverage over time. Before final submission or release, re-check the current `NSPrivacyAccessedAPIType` and `NSPrivacyAccessedAPITypeReasons` documentation and do not invent broad or convenient reasons.
+
+## Privacy Manifest Structure
+
+```xml
+<!-- PrivacyInfo.xcprivacy -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <!-- Declare every data type you collect -->
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>
+```
+
+## Required API Reason Codes
+
+Use the exact approved reason that matches the app or SDK behavior. Do not use a broad reason code because it is convenient; Apple requires the declared reason to match the presented functionality and derived-data use.
+
+Before final submission, re-check Apple's current required-reason API documentation. Reason-code coverage can change, and invented or overly broad reasons are not acceptable.
+
+| API Category | Code | Reason |
+|---|---|---|
+| FileTimestamp | `DDA9.1` | Display file timestamps to the person using the device |
+| FileTimestamp | `C617.1` | Access timestamps, size, or metadata for files in the app, app group, or CloudKit container |
+| FileTimestamp | `3B52.1` | Access timestamps, size, or metadata for user-granted files or directories |
+| FileTimestamp | `0A2A.1` | Third-party SDK wrapper around file timestamp APIs, only when called by the app |
+| SystemBootTime | `35F9.1` | Measure elapsed time between events |
+| SystemBootTime | `8FFB.1` | Calculate absolute timestamps for events that occurred within the app |
+| SystemBootTime | `3D61.1` | Include system boot time in an optional user-submitted bug report |
+| DiskSpace | `85F4.1` | Display disk space information to the person using the device |
+| DiskSpace | `E174.1` | Check available or low disk space before writes or cleanup |
+| DiskSpace | `7D9E.1` | Include disk space information in an optional user-submitted bug report |
+| DiskSpace | `B728.1` | Health research app detects low disk space impacting research data collection |
+| ActiveKeyboards | `3EC4.1` | Custom keyboard app checks active keyboards |
+| ActiveKeyboards | `54BD.1` | Present UI that visibly changes based on active keyboards |
+| UserDefaults | `CA92.1` | Read/write information accessible only to the app itself |
+| UserDefaults | `1C8F.1` | Read/write information accessible only within the same App Group |
+| UserDefaults | `C56D.1` | Third-party SDK wrapper around UserDefaults APIs, only when called by the app |
+| UserDefaults | `AC6B.1` | Managed app configuration or managed feedback keys for MDM |
+
+## Privacy Manifest Keys Reference
+
+| Key | Type | Purpose |
+|---|---|---|
+| `NSPrivacyTracking` | Boolean | Whether the app tracks users (triggers ATT requirement) |
+| `NSPrivacyTrackingDomains` | Array of strings | Domains used for tracking (connected only after ATT consent) |
+| `NSPrivacyCollectedDataTypes` | Array of dicts | Each data type collected, its purpose, and whether it is linked to identity |
+| `NSPrivacyAccessedAPITypes` | Array of dicts | Each required-reason API used and the justification codes |
+
+## Third-Party SDK Manifests
+
+- Verify each SDK, executable, or dynamic library that uses required-reason APIs includes `PrivacyInfo.xcprivacy` in the bundle containing that code
+- Ensure SDK reason codes match actual SDK usage; an SDK cannot rely on the host app's manifest to report the SDK's own required-reason API use
+- Update SDK versions when required manifests or reason declarations are missing
+- Keep the app's manifest focused on app code and app-level collected data/tracking declarations
+
+## Collected Data Types Declaration
+
+Each `NSPrivacyCollectedDataTypes` entry must specify:
+
+- `NSPrivacyCollectedDataType` (category)
+- `NSPrivacyCollectedDataTypeLinked` (linked to identity)
+- `NSPrivacyCollectedDataTypeTracking` (used for tracking)
+- `NSPrivacyCollectedDataTypePurposes` (purposes array)
+
+Keep manifests, privacy nutrition labels, SDK behavior, and app functionality consistent. Mismatches cause rejection.
+
+## Sources To Re-Check
+
+- Required-reason API overview: https://sosumi.ai/documentation/bundleresources/describing-use-of-required-reason-api
+- Required-reason API categories: https://sosumi.ai/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitype
+- Required-reason codes: https://sosumi.ai/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitypereasons

--- a/plugins/app-store-review/references/review-checklists.md
+++ b/plugins/app-store-review/references/review-checklists.md
@@ -1,0 +1,174 @@
+# App Store Review Checklists
+
+## Contents
+- App Review Information Checklist
+- Privacy Manifest Checklist
+- In-App Purchase Checklist
+- Screenshot and App Preview Checklist
+- HIG Compliance Checklist
+- Pre-Submission Checklist
+- Cross-Platform Stack Checklist (React Native / Expo / EAS / RevenueCat)
+
+## App Review Information Checklist
+
+Use this to avoid Guideline 2.1 rejections:
+
+- [ ] Demo credentials provided in App Review Information notes (if login required)
+- [ ] Demo mode available if credentials are impractical or account state is hard to reproduce
+- [ ] Demo account works and has access to all features
+- [ ] App Review notes explain login-gated, role-gated, region-gated, hardware-gated, or otherwise non-obvious features
+- [ ] All screens have real content (no placeholders or Lorem Ipsum)
+- [ ] No broken links or dead-end flows
+- [ ] All hardware-required features have fallback or reviewer instructions
+
+## Privacy Manifest Checklist
+
+Verify PrivacyInfo.xcprivacy completeness:
+
+- [ ] `PrivacyInfo.xcprivacy` exists where app code, SDK code, executables, or dynamic libraries need it
+- [ ] All required-reason API categories in app and bundled SDK code are declared with approved reason codes
+- [ ] `NSPrivacyTracking` is true only if tracking occurs
+- [ ] Third-party SDK manifests present and up to date when SDKs collect data, use required-reason APIs, enable data collection, or contact tracking domains
+- [ ] Privacy nutrition labels match actual data collection
+- [ ] Audit runtime network traffic and SDK transmissions; observed behavior must match privacy labels, manifests, privacy policy, and ATT state
+
+## In-App Purchase Checklist
+
+- [ ] Digital goods and subscriptions use StoreKit IAP unless current storefront rules or approved entitlements allow otherwise
+- [ ] Subscription price, duration, billing frequency, auto-renewal terms, and any trial duration/post-trial price shown before purchase
+- [ ] Restore purchases button present and functional
+- [ ] No external purchase path, link, button, or call to action for digital goods unless current rules or approved entitlements allow it
+- [ ] Ask-to-buy and interrupted purchases handled
+- [ ] Transaction verification uses StoreKit 2 or server-side verification
+
+## Screenshot and App Preview Checklist
+
+- [ ] 1-10 screenshots uploaded for each required platform and localization
+- [ ] iPhone screenshots use current App Store Connect accepted sizes; 6.9-inch iPhone screenshots are the primary set as of May 2026
+- [ ] 6.5-inch iPhone screenshots provided only when 6.9-inch iPhone screenshots are not provided or when manually optimizing that fallback
+- [ ] 13-inch iPad screenshots provided if the app runs on iPad
+- [ ] Screenshots and preview videos show actual app UI and do not misrepresent unavailable features
+- [ ] App previews are 30 seconds or shorter, with a poster frame that works without autoplay
+
+## HIG Compliance Checklist
+
+### Navigation
+- [ ] `NavigationStack` used (not `NavigationView`)
+- [ ] System back chevron used; no custom back icons
+- [ ] Tab bar uses <= 5 tabs; use More tab if needed
+- [ ] Avoid hamburger menus
+
+### Modals and Sheets
+- [ ] Sheets have a visible dismiss control
+- [ ] Full-screen modals have close/done button
+- [ ] Alerts use system alert styles
+
+### System Feature Support
+- [ ] Dark Mode renders correctly
+- [ ] Dynamic Type supported throughout
+- [ ] iPad multitasking supported (Slide Over, Split View)
+- [ ] Dynamic Island / Live Activities render correctly when used
+- [ ] System gestures not disabled
+
+### Widgets and Live Activities
+- [ ] Widgets show real content (not placeholders)
+- [ ] Timelines update meaningfully
+- [ ] Live Activities show time-sensitive info
+- [ ] Lock Screen widgets are legible at small sizes
+
+## Pre-Submission Checklist
+
+### Completeness
+- [ ] No placeholder or test content
+- [ ] All features functional without special hardware
+- [ ] Demo credentials or demo mode provided, with App Review notes for gated or non-obvious features
+- [ ] No dead-end screens
+
+### Metadata
+- [ ] App name matches functionality
+- [ ] Screenshots are real app screenshots using current required platform sizes, including 6.9-inch iPhone and 13-inch iPad when applicable
+- [ ] Description contains no prices or competitor mentions
+- [ ] Category is correct
+
+### Privacy
+- [ ] Privacy manifest present where required, with approved reason codes
+- [ ] Third-party SDK manifests verified
+- [ ] Privacy policy URL present and accessible
+- [ ] Audit runtime network traffic and SDK transmissions; nutrition labels, privacy manifest declarations, privacy policy, and observed behavior match actual data collection
+- [ ] ATT prompt only if tracking occurs
+
+### Payments
+- [ ] Digital content uses StoreKit IAP unless current rules or approved entitlements allow otherwise
+- [ ] Subscription price, duration, billing frequency, auto-renewal terms, and any trial duration/post-trial price visible before purchase
+- [ ] No external purchase paths, payment links, buttons, or calls to action unless current storefront rules or approved entitlements allow them
+- [ ] Free trial terms clear
+- [ ] Restore purchases implemented
+
+### Design
+- [ ] Standard navigation patterns used
+- [ ] Dark Mode supported
+- [ ] Dynamic Type supported
+- [ ] No custom alerts mimicking system alerts
+- [ ] Launch screen not an ad
+- [ ] Empty states provide guidance
+
+### Technical
+- [ ] Built with Xcode 26 or later and relevant platform SDK 26 or later for uploads after April 28, 2026
+- [ ] No private API usage
+- [ ] No dynamic code execution
+- [ ] Entitlements justified with usage descriptions
+- [ ] Background modes justified and used
+- [ ] Deployment target is intentionally chosen and tested
+
+## Cross-Platform Stack Checklist (React Native / Expo / EAS / RevenueCat)
+
+Field-tested gates from real rejections. Full root-cause analysis in [field-lessons-rn-expo.md](field-lessons-rn-expo.md).
+
+### Interactive elements (2.1(a))
+- [ ] Every element with `accessibilityRole="button"` has an `onPress` (or an explicit, documented `disabled` state)
+- [ ] "Rate app" falls back to the App Store product page — the native prompt is a silent no-op in review builds
+- [ ] No nested confirmation sheets; one confirmation is presented at a time
+- [ ] Every Settings action produces a visible result (rate, delete account, logout, support)
+
+### Authentication (2.1(a), 4.8)
+- [ ] A `null` auth event never clears an established session without a settle window or revalidation against the native SDK
+- [ ] Sign-out does not tear down the listener lifecycle needed by the next sign-in
+- [ ] Network/offline errors are not treated as sign-out
+- [ ] Sign in with Apple present when third-party login is offered: fresh nonce per attempt, silent cancellation handled, name persisted only on first authorization, `@privaterelay.appleid.com` accepted
+- [ ] Cold start, reload with persisted session, logout, user switch, and network loss tested on iPhone **and** iPad in a release build
+
+### Purchases (2.1(b), 3.1.1, 3.1.2)
+- [ ] Paid Applications Agreement is `Active`
+- [ ] Entitlement sync invalidates the provider cache and reads fresh customer info before falling back to the backend
+- [ ] Pending server validation retries with backoff, then falls back to local customer info — never leaves content locked
+- [ ] Entitlement grant re-renders the UI without an app restart
+- [ ] Purchase tested in sandbox on a **physical iPad** (simulator does not reproduce sandbox IAP faithfully)
+- [ ] Billed amount is the largest, highest-contrast element in each plan card; derived per-period prices are computed from the live product price, never hardcoded
+- [ ] No external purchase path, deep link, route, or offering load for digital goods remains reachable on iOS
+- [ ] Credit ledger entries originate only from an authenticated server webhook, idempotent on the provider event id, and are blocked client-side by security rules
+
+### App Store Connect metadata
+- [ ] IAP display name (30 chars) and description (45 chars) unique per product **within each locale**
+- [ ] Promo images deleted, or visually distinct per promoted product (1024×1024, no transparency, no rounded corners)
+- [ ] Age Rating declares only features a reviewer can locate and operate
+- [ ] Support URL resolves to a page where a user can actually request support (verify the deployed anchor)
+- [ ] Terms of Use configured in all three places: App Information EULA, App Description (every locale), and Subscription Terms of Use URL; both Terms and Privacy return HTTP 200
+- [ ] Screenshots captured from the candidate build — never mockups, promotional renders, or non-iOS device chrome
+- [ ] Every locale, device family, size, and orientation slot audited via **View All Sizes in Media Manager**; no stale assets remain
+- [ ] Upload target locale matches the asset language (the binary's language does not select metadata language)
+
+### Permissions (5.1.1(iv))
+- [ ] Pre-permission buttons say "Continue"/"Next", never "Grant Permission" — visible label **and** `accessibilityLabel`
+- [ ] The "Open Settings" recovery branch is preserved for the already-denied case
+
+### Account and enrollment (5.1.1(ix))
+- [ ] Developer Program enrollment type matches the app category; regulated categories require organization enrollment (not fixable in code — resolve before spending cycles on fixes)
+
+### Build and submission pipeline
+- [ ] Lockfile in sync with the manifest, generated on the CI Node major; both files committed together
+- [ ] Build number verified higher than the last uploaded build via the App Store Connect API
+- [ ] The fix commit is an ancestor of the submitted build's revision
+- [ ] Four states verified independently: cloud build finished → submit processed → build attached to the version → Update Review
+- [ ] Sandbox testers created (App Store Connect UI only — no API endpoint)
+- [ ] API credentials (`.p8`, issuer id, key id) outside the repo and gitignored; JWTs never logged or committed
+- [ ] **Stopped before `Update Review`** and obtained explicit owner confirmation

--- a/plugins/apple-store-release-agent/SKILL.md
+++ b/plugins/apple-store-release-agent/SKILL.md
@@ -123,8 +123,17 @@ A run can only return **GO** when **all** hold:
 - [ ] No obvious `Alert.alert`/`Alert.prompt` native alerts that hurt review UX (WARNING, not blocker)
 - [ ] No secret files staged for commit (`.env`, `GoogleService-Info.plist`, service accounts)
 - [ ] `EXPO_PUBLIC_USE_MOCK` not `true` in production env (heuristic)
+- [ ] Lockfile is in sync with the manifest and was regenerated on the CI Node major; `npm ci` is expected to pass
+- [ ] Build number is monotonic, single-use, and higher than the last uploaded build, verified through the App Store Connect API
+- [ ] The fix commit is an ancestor of the revision included in the candidate build
+- [ ] Four pipeline states are independently verified: cloud build finished, submit processed, build attached to the App Store version, and `Update Review`
+- [ ] The workflow stops before `Update Review` and waits for explicit account-owner confirmation
 
 Any failed gate → at least `GO_WITH_WARNINGS`. Failed **security/legal** gates (secrets, gambling wording, missing account deletion) → `NO_GO`.
+
+### Submission-state guardrail
+
+Never treat an EAS `finished` result as proof that the reviewed binary is attached to the App Store version. Record the build number, commit revision, processing state, submission state, and version attachment separately. A build that finished before the fix commit, or a build that was processed but never attached to the version, does not satisfy the review gate. Do not run `eas submit`, `Update Review`, or reviewer-facing actions automatically; stop and request owner confirmation.
 
 ---
 

--- a/plugins/apple-store-release-agent/checklists/expo-eas-submit.md
+++ b/plugins/apple-store-release-agent/checklists/expo-eas-submit.md
@@ -29,8 +29,13 @@ Build + submit via EAS. Items marked `# APPROVAL` require explicit human confirm
 - [ ] Build status "Processing" → "Ready" in App Store Connect (human-monitored)
 - [ ] Add internal testers in TestFlight
 - [ ] Run `checklists/testflight-smoke.md` on the TF build
+- [ ] Keep these states distinct: cloud build finished → submit processed → build attached to the App Store version → `Update Review`
+- [ ] Verify the fix commit is an ancestor of the revision in the candidate build
 
 ## Pre-Submit Sanity
 - [ ] `node scripts/validate-ios-release.mjs --project . --strict` passes
+- [ ] Lockfile is in sync and was generated on the CI Node major; `npm ci` passes
+- [ ] Build number is higher than the last uploaded build, verified through the App Store Connect API
 - [ ] Decision is GO / GO_WITH_WARNINGS (no open BLOCKER)
 - [ ] Review Notes + metadata attached in App Store Connect
+- [ ] Stop before `Update Review` and obtain explicit account-owner confirmation

--- a/plugins/apple-store-release-agent/checklists/revenuecat-iap.md
+++ b/plugins/apple-store-release-agent/checklists/revenuecat-iap.md
@@ -16,7 +16,8 @@ Validate IAP before App Review. BLOCKER items force NO_GO.
 
 ## Sandbox
 - [ ] Sandbox tester account created in App Store Connect
-- [ ] Sandbox purchase tested end-to-end on a TF build
+- [ ] Paid Applications Agreement is `Active`
+- [ ] Sandbox purchase tested end-to-end on a **physical iPad** in a release/TestFlight build
 - [ ] Restore Purchases tested after sandbox purchase
 - [ ] Subscription renewal/cancellation flow verified in sandbox
 
@@ -29,12 +30,15 @@ Validate IAP before App Review. BLOCKER items force NO_GO.
 - [ ] Paywall shows price, period, terms
 - [ ] Subscription auto-renew terms disclosed near purchase
 - [ ] Paywall has graceful fallback if offering/products fail to load
+- [ ] Entitlement sync invalidates the RevenueCat cache, reads fresh `customerInfo`, retries with backoff, then falls back to local entitlement state before leaving premium locked
+- [ ] Premium UI re-renders immediately after entitlement grant; no app restart is required
 - [ ] No external payment links / web checkout — ⚠️ BLOCKER
 
 ## Webhook / Ledger (if backend-managed)
 - [ ] RevenueCat webhook → backend verified
 - [ ] Entitlement ledger idempotent (no double-grant)
 - [ ] Refund/cancellation events handled
+- [ ] Backend validation remains asynchronous after the local fallback; the anti-fraud trade-off is documented and revocation is supported
 
 ## Wording Risk — ⚠️ BLOCKER
 - [ ] No "earn money / ganhe dinheiro / lucro / renda garantida / cashout / saque garantido"

--- a/plugins/aso/SKILL.md
+++ b/plugins/aso/SKILL.md
@@ -310,3 +310,4 @@ the app's brand maturity tier — they may be deliberate choices for Dominant ap
 - **ad-creative**: For creating App Store and Google Play ad creatives
 - **analytics**: For setting up install attribution and in-app event tracking
 - **customer-research**: For understanding user needs and language to inform listing copy
+- **app-store-review**: For App Review compliance, metadata accuracy, screenshot-slot audits, and rejection prevention. Keep keyword strategy, ranking, and conversion optimization in this skill.

--- a/plugins/google-play-release-agent/SKILL.md
+++ b/plugins/google-play-release-agent/SKILL.md
@@ -98,6 +98,7 @@ Before the agent can emit anything better than **NO_GO**, the project must show:
 
 - `android.package` set (reverse-DNS, valid)
 - `versionCode` is a positive integer and incremented vs prior release
+- `versionCode` is monotonic and single-use; verify it against the last uploaded artifact before submission
 - `versionName` set
 - `eas.json` has a `production` profile
 - Build target produces `.aab` (not only `.apk`)
@@ -108,6 +109,7 @@ Before the agent can emit anything better than **NO_GO**, the project must show:
 - All sensitive permissions justified
 - Data Safety suggestions reviewed by a human
 - RC/IAP products referenced in code have matching store metadata
+- If the project uses npm, the lockfile is in sync and was regenerated on the CI Node major so `npm ci` will not fail in the release environment
 
 ## Suggested commands
 

--- a/plugins/google-play-release-agent/checklists/expo-eas-submit.md
+++ b/plugins/google-play-release-agent/checklists/expo-eas-submit.md
@@ -11,6 +11,8 @@
 - [ ] Output is `.aab` (not `.apk`)
 - [ ] `EXPO_PUBLIC_USE_MOCK=false` in production profile
 - [ ] versionCode incremented
+- [ ] versionCode is monotonic and single-use relative to the last uploaded artifact
+- [ ] Lockfile is in sync and `npm ci` passes on the CI Node major
 - [ ] Package name matches Play Console app
 
 ## Submit


### PR DESCRIPTION
## Summary

- Adds the new marketplace plugin `app-store-review`, based on the validated cross-platform App Review material from the source app.
- Adds the full React Native / Expo / EAS / RevenueCat rejection reference, privacy-manifest reference, cross-platform checklist, and eval cases 4–6.
- Registers the plugin in `.claude-plugin/marketplace.json` with metadata copied from its `plugin.json`.
- Updates the existing Apple release, App Store Connect API, ASO, and Google Play release skills with the corresponding pipeline, metadata, IAP, subscription, screenshot, entitlement, and versioning guardrails.

## Cross-platform coverage

The new skill documents:

- Five rejection cycles and the meta-lessons around repeated guidelines, iPad-only failures, release-build bridge ordering, and verifying the reviewed binary.
- Dead interactive elements, the silent native review-prompt no-op, nested sheet races, Firebase auth null-flash login loops, and the two-layer auth fix.
- RevenueCat sandbox entitlement races, cache invalidation, fresh `customerInfo`, backoff, local fallback, re-render without restart, and the explicit anti-fraud trade-off.
- Subscription price hierarchy, non-IAP digital currency paths, duplicate IAP metadata, age-rating accuracy, screenshot-slot audits, permission copy, enrollment, Sign in with Apple, support/EULA links, and App Store Connect API limits.
- Build/submit/version/attachment/`Update Review` state separation, monotonic build numbers, CI Node-major lockfile checks, and the owner-confirmation stop gate.

## Scope boundary

- Work was isolated in `codex/app-store-review-field-lessons` under `.claude/worktrees/app-store-review-field-lessons`.
- The Claude session's existing `main` worktree changes were not copied, staged, committed, or modified.
- The requested `revenuecat-integration` skill does not exist in this checkout, so no unrelated replacement plugin was invented; RevenueCat guidance was added to `app-store-review` and the existing Apple release checklist instead.
- No App Store Connect submission, metadata mutation, deployment, or production release action was performed.

## Validation

- `python3 scripts/validate_plugins.py --severity warn` — 163 plugins, 0 errors, 0 warnings.
- `python3 -m unittest discover -s scripts/tests` — 54 tests passed.
- `python3 -m json.tool` passed for the new evals, plugin manifest, and marketplace manifest.
- Marketplace directory/registry invariant passed for all 163 plugins; new entry metadata matches `plugins/app-store-review/plugin.json`.
- The three requested source files (`field-lessons-rn-expo.md`, `review-checklists.md`, `evals.json`) match the validated source byte-for-byte.
- `git diff --check` passed.

## Commit

`d0febd0 feat(app-store-review): add cross-platform rejection guidance`
