### PR TITLE
feat(plugins): add logo creator expert skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1396,6 +1396,23 @@
       ]
     },
     {
+      "name": "logo-creator-expert",
+      "source": "./plugins/logo-creator-expert",
+      "description": "Design minimalist, single-gesture brand marks that remain legible at 16px, with product-grounded concepts, real-size contact sheets, and a complete export ladder.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "logo",
+        "branding",
+        "favicon",
+        "app-icon",
+        "minimalist-design",
+        "logo-creator-expert"
+      ]
+    },
+    {
       "name": "marketing-council",
       "source": "./plugins/marketing-council",
       "description": "When the user wants multiple expert perspectives on a marketing question \u2014 a simulated board of advisors staffed by legendary marketers (Seth Godin, David Ogilvy, Eugene Schwartz, April Dunford, Rory Sutherland, Alex Hormozi, Byron Sharp, and more). Also use when the user mentions 'marketing council,' 'board of advisors,' 'advisory board,' 'what would Seth Godin say,' 'what would Ogilvy think,' 'channel Hormozi,' 'get multiple perspectives,' 'debate this,' 'have the council review,' 'marketing mentors,' or asks how a famous marketer would approach their problem. The council gives each advisor's take through their documented frameworks, surfaces where they disagree, and synthesizes a recommendation. For executing the winning direction, hand off to positioning, offers, copywriting, ads, or the relevant skill.",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -797,6 +797,21 @@
       ]
     },
     {
+      "name": "design-expert",
+      "source": "./plugins/design-expert",
+      "description": "Canonical Apple-inspired frontend design orchestrator for distinctive, accessible, conversion-aware pages and components.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "design",
+        "frontend",
+        "apple-inspired",
+        "motion"
+      ]
+    },
+    {
       "name": "design-taste-frontend",
       "source": "./plugins/design-taste-frontend",
       "description": "Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that do not look templated. Real design systems when applicable, audit-first on redesigns, strict pre-flight check.",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ Open the interactive installer, or install a plugin by name using the `plugin@ma
 /plugin install agentic-value-loops@lemon-ai-hub
 ```
 
+### 3. Install one skill with `npx skills`
+
+Install only a selected skill for a supported agent instead of the complete hub:
+
+```bash
+npx skills add https://github.com/Andersonlimahw/lemon-ai-hub/tree/main/plugins/logo-creator-expert --global --yes
+```
+
+The repository helper targets the skill directory directly and accepts the same `skills add` options:
+
+```bash
+./scripts/add-skill.sh logo-creator-expert --global --yes --agent claude-code
+```
+
 | Plugin | Description |
 | --- | --- |
 | `a11y-audit` | WCAG 2.1 AA/AAA accessibility audit for web components, pages, and apps. Detects contrast failures, missing ARIA labels, keyboard trap issues, focus order problems, and screen-reader gotchas. Use when user wants to audit accessibility, fix a11y warnings, prepare for compliance review, or validate UI against WCAG standards. |
@@ -51,6 +65,7 @@ Open the interactive installer, or install a plugin by name using the `plugin@ma
 | `analytics` | When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions "set up tracking," "GA4," "Google Analytics," "conversion tracking," "event tracking," "UTM parameters," "tag manager," "GTM," "analytics implementation," "tracking plan," "how do I measure this," "track conversions," "attribution," "Mixpanel," "Segment," "are my events firing," or "analytics isn't working." Use this whenever someone asks how to know if something is working or wants to measure marketing results. For A/B test measurement, see ab-testing. |
 | `api-test-loop` | API Test Loop plugin — Automated REST API validation loop. Executes HTTP requests via CURL, logs findings for REST best practices (method, input/output format, security, performance, docs), and implements backend fixes. |
 | `app-store-connect-api` | Apple Store Connect API Expert Agent and Skills. Provides comprehensive tools and knowledge for interacting with the App Store Connect API, covering domains like TestFlight, In-app purchases, Subscriptions, App management, and Provisioning. |
+| `app-store-review` | Prepare for Apple App Store review and prevent rejections across native and React Native/Expo/EAS apps. Covers review guidelines, PrivacyInfo.xcprivacy, IAP and StoreKit, ATT, metadata, screenshots, App Store Connect pipeline gates, RevenueCat entitlement races, and field-tested rejection patterns. |
 | `apple-store-release-agent` | AI release agent for the Apple App Store. Audits Expo/React Native iOS builds, App Store metadata, App Privacy readiness, TestFlight, RevenueCat/IAP, Firebase, i18n parity, screenshots, and review notes, then emits a GO/GO_WITH_WARNINGS/NO_GO decision with full risk + privacy + IAP reports. Never submits to App Review or alters the store without explicit human approval. Generic core with presets for Expo/RN/Firebase/RevenueCat apps. |
 | `architecture-deepener` | Surface opportunities to deepen a codebase. Finds shallow modules (thin pass-throughs, anemic types, domain logic leaking into controllers/UI) and proposes deep modules that co-locate behavior with data, enforce invariants, and stay navigable for humans and AI agents. Emits a visual HTML report and runs an interactive grilling loop that pressure-tests each opportunity before any code moves. Integrates with domain-modeling, codebase-design, and ADR workflows. |
 | `aso` | When the user wants to audit or optimize an App Store or Google Play listing. Also use when the user mentions 'ASO audit,' 'app store optimization,' 'optimize my app listing,' 'improve app visibility,' 'app store ranking,' 'audit my listing,' 'why aren't people downloading my app,' 'improve my app conversion,' 'keyword optimization for app,' or 'compare my app to competitors.' Use when the user shares an App Store or Google Play URL and wants to improve it. |
@@ -129,6 +144,7 @@ Open the interactive installer, or install a plugin by name using the `plugin@ma
 | `llm-wiki-curator` | Maintains docs/ in the Karpathy-style LLM-wiki standard. Generates docs/llms.txt (flat machine-readable index conforming to llmstxt.org), validates broken links, enforces a minimum front-matter in new .md files (title, status, updated, related), groups orphan docs. Use when the user says "update docs index", "generate llms.txt", "audit docs", "organize wiki", "cure documentation", or after adding/renaming a file in docs/. |
 | `load-test` | Load testing setup, execution, and analysis with k6, Artillery, or Locust. Generates test scripts, defines VU ramp-up scenarios, interprets p99 latency and error rate results, and suggests infrastructure fixes. Use when user wants to load test an API, check throughput limits, validate SLO headroom, or diagnose performance under traffic. |
 | `load-test-runner` | Load testing orchestration plugin. Manages k6 and Artillery test suites, schedules nightly soak tests, stores historical performance baselines, detects performance regressions between releases, and generates Grafana-compatible performance reports. Tracks p50/p95/p99 trends over time. |
+| `logo-creator-expert` | Design minimalist, single-gesture brand marks that remain legible at 16px, with product-grounded concepts, real-size contact sheets, and a complete export ladder. |
 | `marketing-council` | When the user wants multiple expert perspectives on a marketing question — a simulated board of advisors staffed by legendary marketers (Seth Godin, David Ogilvy, Eugene Schwartz, April Dunford, Rory Sutherland, Alex Hormozi, Byron Sharp, and more). Also use when the user mentions 'marketing council,' 'board of advisors,' 'advisory board,' 'what would Seth Godin say,' 'what would Ogilvy think,' 'channel Hormozi,' 'get multiple perspectives,' 'debate this,' 'have the council review,' 'marketing mentors,' or asks how a famous marketer would approach their problem. The council gives each advisor's take through their documented frameworks, surfaces where they disagree, and synthesizes a recommendation. For executing the winning direction, hand off to positioning, offers, copywriting, ads, or the relevant skill. |
 | `marketing-ideas` | When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' 'ideas to grow,' 'what else can I try,' 'I don't know how to market this,' 'brainstorm marketing,' or 'what marketing should I do.' Use this as a starting point whenever someone is stuck or looking for inspiration on how to grow. For specific channel execution, see the relevant skill (ads, social, emails, etc.). |
 | `marketing-loops` | When the user wants to set up a recurring, self-running marketing workflow — a repeatable loop an AI agent runs on a cadence (weekly, daily, on a trigger) rather than a one-off task. Also use when the user mentions 'marketing loop,' 'recurring marketing workflow,' 'automate my marketing,' 'marketing on autopilot,' 'weekly marketing review,' 'ad fatigue check,' 'content refresh loop,' 'churn watch,' 'ranking drop alert,' 'always-on marketing,' 'marketing automation workflow,' or 'run this every week.' Use this to pick, adapt, and schedule an ongoing marketing loop that orchestrates the other marketing skills. For one-off marketing ideas, see marketing-ideas. For the experimentation loop specifically, see ab-testing. |
@@ -263,4 +279,3 @@ bash -c "$(curl -fsSL https://raw.githubusercontent.com/Andersonlimahw/lemon-ai-
 
 ---
 *Built with 🍋 by Anderson Lima.*
-

--- a/docs/cli-marketplace.md
+++ b/docs/cli-marketplace.md
@@ -37,3 +37,16 @@ Prints the full implementation file (`SKILL.md`) of the specified skill directly
 ```bash
 ./scripts/marketplace info senior-prompt-engineer
 ```
+
+### 5. Install one skill with `npx skills`
+The helper installs only the selected plugin directory through the open skills CLI:
+
+```bash
+./scripts/add-skill.sh logo-creator-expert --global --yes --agent claude-code
+```
+
+The equivalent direct command is:
+
+```bash
+npx skills add https://github.com/Andersonlimahw/lemon-ai-hub/tree/main/plugins/logo-creator-expert --global --yes
+```

--- a/plugins/design-expert/SKILL.md
+++ b/plugins/design-expert/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: design-expert
+description: Create, redesign, critique, and ship distinctive production frontend pages and components. Orchestrates design, design-taste-frontend, frontend-design, impeccable, revenue-centric-design, scroll-world, and ui-ux-pro-max in lexical order. Use for UI structure, visual systems, responsive layouts, interaction, motion, and visual QA; skip backend-only work.
+metadata:
+  short-description: Canonical Apple-inspired frontend design orchestrator
+---
+
+# Design Expert
+
+Act as a principal product designer and frontend engineer. Produce interfaces that feel authored, precise, calm, fast, and memorable. Use Apple Human Interface Guidelines principles as a web-quality north star—clarity, deference, depth, hierarchy, continuity, and accessibility—without pretending a website is native iOS or calling web glassmorphism official Liquid Glass.
+
+This skill is canonical for new pages, page redesigns, reusable components, design-system work, UI critique, and frontend polish. It composes seven companion skills. Consult them in this exact lexical order; do not let a later module erase a stronger usability, accessibility, performance, or product constraint.
+
+## Companion stack — lexical order
+
+1. **design**
+   Establish brand intent, visual direction, semantic tokens, composition, and reusable primitives. For a new system, define brand → tokens → implementation before styling isolated components.
+
+2. **design-taste-frontend**
+   Enforce anti-slop discipline, authored composition, realistic content, controlled asymmetry, responsive intent, and accessibility/performance guardrails. Treat its forbidden-pattern list as a review checklist.
+
+3. **frontend-design**
+   Translate the design thesis into production-grade frontend code that fits the repository’s stack, architecture, and existing conventions. Keep implementation complete: states, responsive behavior, interaction, and integration.
+
+4. **impeccable**
+   Critique, audit, polish, harden, typeset, layout, colorize, and animate as needed. Use its focused references or commands only for the active mode; do not load unrelated reference packs.
+
+5. **revenue-centric-design**
+   Connect hierarchy and interaction to user value, activation, trust, retention, or conversion when the surface has a business goal. Optimize for clarity and informed action; never use dark patterns, false urgency, or obstructive cancellation.
+
+6. **scroll-world**
+   Use only when the brief calls for a cinematic scroll narrative, 3D/diorama world, camera flight, or scroll-scrubbed story. It is an optional art-direction mode, never a default effect on ordinary pages.
+
+7. **ui-ux-pro-max**
+   Use for design-system intelligence, pattern selection, style direction, color, typography, landing-page structure, and anti-pattern checks. When its design-system generator exists in the active runtime, use it before committing to a new visual system.
+
+If nested skill invocation is supported, invoke `$design`, `$design-taste-frontend`, `$frontend-design`, `$impeccable`, `$revenue-centric-design`, `$scroll-world`, and `$ui-ux-pro-max` in that order. If not supported, resolve each `SKILL.md` from the runtime overlay or the hub source and apply the same contract. Keep heavy companion references conditional.
+
+## Operating contract
+
+### 1. Read the room
+
+Before choosing visuals, identify:
+
+- surface type, audience, user intent, product promise, and one primary action;
+- content density, states, data shape, localization needs, and device context;
+- existing tokens, components, fonts, assets, routing, and framework conventions;
+- business outcome, if any, and the evidence that can honestly support it.
+
+Do not invent product facts, testimonials, metrics, names, or brand claims. If the brief is incomplete, make the smallest safe assumption and encode it as a design decision.
+
+### 2. Define one visual thesis
+
+Write one sentence describing the page’s visual idea before coding. Build a small design grammar around it:
+
+- one dominant composition or focal object;
+- one signature interaction or spatial move;
+- one type system with clear display, body, label, and numeric roles;
+- one semantic color system with purposeful accent use;
+- one spacing and radius language;
+- one depth model: flat, layered, translucent, or spatial—not all at once.
+
+Use tension deliberately: asymmetric grids, interrupted alignment, editorial cropping, oversized type, unusual but legible density, or a non-uniform section rhythm. Every disruption must improve hierarchy, story, or memory. Novelty that harms comprehension is a defect.
+
+### 3. Apple-inspired web principles
+
+- **Clarity:** content, affordance, status, and next action remain obvious at a glance.
+- **Deference:** chrome supports content; decoration never competes with the user’s task.
+- **Depth:** layers, scale, blur, shadow, and motion explain relationships and continuity.
+- **Precision:** align to a deliberate grid; use optical correction where mathematical alignment looks wrong.
+- **Continuity:** transitions preserve object identity, spatial cause, and user orientation.
+- **Adaptivity:** layout, type, density, and interaction adapt to width, input method, contrast, locale, and reduced motion.
+- **Restraint:** use rounded surfaces, blur, gradients, shadows, and animation as semantic tools, not a visual coating.
+
+For web implementations, prefer semantic HTML, CSS variables, fluid `clamp()` sizing, resilient intrinsic layouts, keyboard-visible focus, and platform-appropriate controls. A Liquid Glass-like treatment is only a transparent, layered, high-contrast web approximation; provide an opaque fallback.
+
+### 4. Anti-AI-slop gate
+
+Reject defaults unless the brief explicitly requires them:
+
+- AI-purple gradients, centered hero over dark mesh, or abstract blobs with no meaning;
+- three identical feature cards in a row;
+- Inter + slate-900 as an unexamined visual system;
+- generic glassmorphism on every surface;
+- perfectly repeated pills, floating cards, and mathematically uniform spacing;
+- decorative dashboard grids with no information hierarchy;
+- fake testimonials, generic avatars, perfect statistics, filler marketing verbs, or placeholder brand names;
+- gradients, particles, parallax, hover tricks, or infinite loops added only to signal “AI-made polish.”
+
+Replace defaults with a specific visual thesis, contextual copy, believable content shape, intentional rhythm, and a small number of meaningful details. Do not hide weak hierarchy under effects.
+
+### 5. Layout system
+
+- Establish hierarchy before ornament: one dominant heading, one primary action, clear supporting content.
+- Use a responsive container and tokens; avoid magic-number drift.
+- Prefer composition with a focal anchor, supporting rail, and readable escape path.
+- Vary section rhythm intentionally; do not stack identical card rows.
+- Use asymmetric or editorial layouts when they reinforce content, then collapse gracefully on narrow screens.
+- Design all relevant states: loading, empty, error, success, disabled, focused, hover, active, overflow, and long-content behavior.
+- Keep touch targets and click targets comfortable; never make precision interaction depend on hover.
+- Preserve reading order and DOM order when visual placement changes.
+
+### 6. Typography and color
+
+- Choose type by role and voice, not popularity. Pair display and reading faces only when contrast adds meaning.
+- Define a compact scale with fluid interpolation; avoid arbitrary one-off sizes.
+- Control line length, leading, tracking, optical weight, and wrapping at every target width.
+- Use semantic color tokens: canvas, surface, elevated surface, ink, muted ink, border, accent, success, warning, and danger.
+- Ensure text, controls, focus indicators, disabled states, and imagery remain legible in light/dark and high-contrast contexts.
+- Use accent color to direct attention or express state. If every element is loud, nothing is primary.
+
+### 7. Fluid motion and animation
+
+Motion must express cause, hierarchy, continuity, or feedback. Set a motion budget before implementation:
+
+- **Intensity 1–3:** static by default; hover, active, and focus feedback only.
+- **Intensity 4–7:** fluid CSS or Motion transitions; favor `transform` and `opacity`, with deliberate easing and stagger.
+- **Intensity 8–10:** advanced choreography only when the page story requires it; isolate expensive effects and test on low-power devices.
+
+Rules:
+
+- Animate state changes, not decoration.
+- Keep transitions short enough to preserve agency; use one coherent easing language.
+- Prefer compositor-friendly properties. Avoid layout thrashing and `window.addEventListener('scroll')` for visual updates.
+- Use CSS scroll-driven animation, `IntersectionObserver`, or the repository’s supported Motion/GSAP integration when appropriate.
+- Never hijack scroll, trap focus, or make content inaccessible while an animation runs.
+- Gate meaningful motion behind `prefers-reduced-motion: no-preference`; collapse parallax, scroll-scrub, magnetic physics, and infinite loops to a static or instant state under `prefers-reduced-motion: reduce`.
+- Keep animation optional on mobile when it competes with content, battery, or input.
+
+### 8. Product and conversion lens
+
+When a page has a business outcome:
+
+- make user value legible before asking for commitment;
+- use one primary CTA per decision context, with a specific verb and clear outcome;
+- place proof near the claim it supports; label evidence honestly;
+- remove friction that does not protect the user, while preserving informed consent;
+- design activation, empty, onboarding, upgrade, and cancellation states as part of the experience;
+- measure success by user progress and sustained value, not clicks alone.
+
+Revenue guidance is subordinate to trust, accessibility, and user control.
+
+### 9. Implementation discipline
+
+- Inspect and reuse existing tokens, primitives, assets, and dependencies before adding new ones.
+- Match repository conventions for framework, styling, routing, state, and testing.
+- Keep component APIs semantic and composable; avoid abstractions that serve one use.
+- Use real assets or intentional placeholders with explicit dimensions; prevent layout shift.
+- Keep visual effects progressive-enhancement friendly and provide contrast-safe fallbacks.
+- Do not use Unicode characters as substitute UI icons when the codebase has an icon system.
+- Do not ship console warnings, hydration mismatches, broken focus, or inaccessible interactive elements.
+
+### 10. Verification gate
+
+Before declaring a page or component complete, verify:
+
+1. visual thesis, hierarchy, spacing rhythm, type, color, and responsive composition;
+2. all interaction and content states, including long content and localization expansion;
+3. keyboard order, visible focus, semantic landmarks, labels, contrast, target size, and screen-reader meaning;
+4. reduced-motion behavior and animation cleanup;
+5. performance: no unnecessary listeners, layout thrashing, oversized assets, or avoidable dependency;
+6. console, typecheck, lint, targeted tests, and the repository’s full quality gate;
+7. visual evidence at narrow, medium, and wide viewports when browser tooling exists.
+
+Run a final anti-slop pass: remove one unnecessary effect, one redundant surface, and one generic pattern if doing so improves clarity. Keep any effect whose removal would damage meaning or orientation.
+
+## Cross-runtime resolution
+
+Canonical source: `~/Projects/IA/lemon-ai-hub/plugins/design-expert/SKILL.md`.
+
+Preferred discovery:
+
+- shared overlay: `~/.agents/skills/design-expert/`;
+- Codex: `~/.agents/skills/design-expert/`, with `~/.codex/skills/` and `~/.codex-lemon-dev/skills/` as harness-specific fallbacks;
+- OpenCode: `~/.config/opencode/skills/design-expert/`;
+- Claude Code: `lemon-ai-hub` marketplace plugin; `~/.claude/skills/` is local-only fallback;
+- Antigravity/Agy: `~/.antigravity/skills/design-expert/` or `~/.agy/skills/design-expert/`;
+- Gemini-backed Antigravity: `~/.gemini/config/skills/design-expert/` when that overlay is active.
+
+Keep one source of truth. Prefer symlinks or marketplace exposure over copied skill bodies. Resolve companion skills from the active overlay first, then the hub. If a companion is unavailable, preserve its contribution through this contract and report missing installation only when it blocks the requested work.

--- a/plugins/design-expert/plugin.json
+++ b/plugins/design-expert/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "design-expert",
+  "version": "1.0.0",
+  "description": "Canonical Apple-inspired frontend design orchestrator for distinctive, accessible, conversion-aware pages and components.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "license": "MIT",
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "design",
+    "frontend",
+    "apple-inspired",
+    "motion"
+  ]
+}

--- a/plugins/logo-creator-expert/SKILL.md
+++ b/plugins/logo-creator-expert/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: logo-creator-expert
+description: Design a minimalist, single-gesture brand mark the way Jony Ive would — one idea, no ornament, tested small before it's called done. Use when the user asks to create/redesign a logo, favicon, or app icon, wants a "minimalist" or "Apple-style" mark, or says a logo feels generic/cluttered/AI-slop.
+---
+
+# Logo Creator Expert
+
+A brand mark is one idea, drawn once, that survives 16px. Everything in this
+skill exists to force that constraint before any pixel is exported.
+
+## Philosophy (non-negotiable)
+
+1. **One gesture, not a scene.** If the mark needs two metaphors ("it's a pin
+   AND a chart AND a handshake"), it is not done — it is three drafts glued
+   together. Pick the single idea that carries the whole meaning.
+2. **The concept must be nameable in five words.** "Y of Your, staked as a
+   pin, seat as the dot." If you can't name it that short, it's decoration,
+   not a concept.
+3. **Negative space is a design decision, not leftover space.** Prefer a
+   knockout, a shared stroke, or a letterform doing double duty over adding
+   another shape.
+4. **Delete until it breaks, then add back one thing.** Every anchor point,
+   gradient, and color must justify its existence. Flat fills over gradients.
+   One accent color over a palette.
+5. **Design at 1024, judge at 16.** A mark that only works large is not a
+   mark, it's an illustration. The kill test is a real (not scaled-up) 16px
+   render next to a real 16px competitor favicon.
+6. **The mark must earn its story from the product, not from mythology.**
+   Don't reach for generic "growth arrows" or "connection nodes" — derive the
+   shape from what the product actually does (see Step 1).
+
+## Process
+
+### Step 0 — Read the brand before drawing anything
+
+Never invent a concept from the brand name alone. Pull real constraints first:
+
+- Read `DESIGN.md` / `docs/brand-guidelines.md` / design-tokens files for
+  existing color tokens (accent, ink, surface) and product posture language.
+- Read `tailwind.config.ts` / `globals.css` / `design-tokens.css` for the
+  actual hex values already shipping in the product — the mark must use them,
+  not invent a new palette.
+- Find the primary UI font already loaded (`next/font/local`, `@font-face`)
+  — the wordmark pairs with what's already shipping, not a new typeface.
+- Note where the mark is actually consumed (favicon tab, app-icon tile,
+  header chip on a light background, dark landing hero, README badge). Each
+  context can demand a different background treatment of the *same* mark —
+  check call sites (`grep -rn "logo\|favicon\|apple-icon" src`) before
+  assuming a transparent PNG is enough.
+
+If invoked with `/brand:brand` or `/design:design` context already loaded in
+the conversation, reuse that instead of re-deriving it.
+
+### Step 1 — Extract the single concept from the product, not the name
+
+Ask: what does this product actually *do*, in one sentence? Turn the core
+mechanic — not the company name — into a visual pun or reduction:
+
+- A market with one ownable unit → the mark should show *one occupied slot*
+  distinct from the rest, not a generic grid/globe/pin.
+  A geographic ownership product ("claim a region on a map") became a Y-shaped
+  pin (Y = "Your") with the seat as a single filled dot at the vertex — one
+  gesture, three meanings (initial, pin, occupancy), same stroke.
+- A messaging product → the mark should show the *exchange*, not a generic
+  chat bubble.
+- A scheduling product → the mark should show the *commitment* (a locked
+  slot), not a generic calendar grid.
+
+Generate 4–6 distinct concepts this way, each a different metaphor for the
+same mechanic — not 6 variations of the same shape.
+
+### Step 2 — Build a real contact sheet, don't eyeball SVG code
+
+Static SVG markup lies about legibility. Render an actual HTML page with all
+candidates at real pixel sizes (128/64/32/16, dark + light background using
+the product's real tokens) and view it with `claude-in-chrome` (or
+`chrome-devtools` MCP) — never judge from the `<path>` coordinates alone.
+
+```bash
+mkdir -p /tmp/<slug>-logo && python3 -m http.server 8899 --directory /tmp/<slug>-logo &
+```
+
+Serve over `http://localhost` rather than `file://` — some MCP screenshot
+paths behave inconsistently with `file://`. Screenshot the sheet, cut
+anything that:
+- reads as a stock icon (generic pin, generic globe, generic chat bubble)
+- needs color to be understood (fails a grayscale/16px squint test)
+- has more than ~4 distinct anchor shapes
+
+Keep 1–2 survivors, then do a second contact-sheet round refining *those*
+concepts' proportions (stroke width, corner radius, optical centering) — not
+inventing new ones. Two rounds is normal; more than three means Step 1 was
+skipped.
+
+### Step 3 — Verify at true small sizes, not scaled-up boxes
+
+A `<div>` with `padding` around a `32px` SVG is not a 32px test — the
+surrounding whitespace lies about density. Render each candidate in a bare
+`<svg width="16" height="16">` (and 24/32/48) with no padding, on the
+product's actual dark and light surface colors, and on the accent color if
+the mark ever sits on a colored tile (app icon, social avatar).
+
+### Step 4 — Produce the deliverable set, not just one PNG
+
+A logo task is done when every consumption context is covered, matched to
+where Step 0 found the mark is actually used:
+
+- **Transparent mark** (ink-colored, no background) — for light chips, docs,
+  anywhere the surrounding surface provides contrast.
+- **App-icon tile** (mark on a solid/branded background, correct corner
+  radius for the platform) — for favicons, apple-touch-icon, PWA icons,
+  social avatars.
+- **Full icon size ladder** matching whatever the codebase already references
+  (`grep` the exact filenames/sizes before generating — don't guess a generic
+  16/32/180/512 set if the project wants 24/72/144/152/384 too).
+- **`favicon.ico`** multi-resolution (16/32/48) if the project ships one.
+- **Editable source** (`.svg`, flat, one `viewBox`, named layers or at least
+  named `<path>` comments) saved back into the repo next to the raster
+  exports — the next person must be able to edit it without re-deriving it.
+
+Render pipeline (no paid AI image generation needed for a geometric mark —
+draw it directly in SVG for pixel-perfect control):
+
+```bash
+rsvg-convert -w <size> -h <size> mark.svg -o icon-<size>.png   # crisp raster
+cwebp -q 90 icon-<size>.png -o icon-<size>.webp                 # web format
+magick icon-16.png icon-32.png icon-48.png favicon.ico          # multi-res ico
+```
+
+### Step 5 — Ship it and verify in the real app, not just the contact sheet
+
+Copy files into place, then start the dev server and load the real page
+(header, favicon tab, login screen) — browsers aggressively cache image URLs
+that keep the same filename, so hard-reload (`cmd+shift+r`) before judging.
+Confirm the mark reads correctly in the actual chip/background it lives in,
+not just the isolated contact sheet.
+
+## Revenue-centric framing (when the mark is for a commercial product)
+
+A logo is not decoration — it is the first trust signal a prospect sees.
+Two [[revenue-centric-design]] principles apply directly:
+
+- **Your promise is the size of your proof.** A logo that overclaims
+  (elaborate, "enterprise-grade"-looking mark on a pre-revenue product) reads
+  as incongruent and erodes trust faster than a plain one. Match visual
+  ambition to actual proof.
+- **Same competes on price, different on category.** A generic
+  pin/chat-bubble/handshake mark makes the product look interchangeable with
+  every competitor using the same stock metaphor. The Step 1 derivation
+  (concept from mechanic, not category convention) is what buys the
+  "different" positioning, not extra ornamentation.
+
+## Anti-patterns (reject these on sight)
+
+- Gradient-heavy "AI startup" orbs/blobs with no derivable meaning.
+- Literal, clipart-style icons (an actual photo-realistic rocket, handshake,
+  lightbulb).
+- Wordmark-only when the product needs a standalone favicon/app-icon — always
+  design the mark to work with the wordmark removed.
+- More than one accent color in the mark itself — let the product's existing
+  token system carry color, don't invent a new palette for the logo alone.
+- Shipping only a 512px PNG and calling it done — see Step 4.

--- a/plugins/logo-creator-expert/plugin.json
+++ b/plugins/logo-creator-expert/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "logo-creator-expert",
+  "version": "1.0.0",
+  "description": "Design minimalist, single-gesture brand marks that remain legible at 16px, with product-grounded concepts, real-size contact sheets, and a complete export ladder.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "license": "MIT",
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "logo",
+    "branding",
+    "favicon",
+    "app-icon",
+    "minimalist-design",
+    "logo-creator-expert"
+  ]
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,6 +29,16 @@ Automatically creates symlinks in the correct directories for all supported agen
 ./scripts/setup-symlinks.sh
 ```
 
+### `add-skill.sh`
+Installs one skill from the public Lemon AI Hub repository through the `npx skills` CLI. The helper targets the selected plugin directory, so it does not install the entire hub.
+
+**Usage:**
+```bash
+./scripts/add-skill.sh logo-creator-expert --global --yes --agent claude-code
+```
+
+Override the source repository or branch when needed with `LEMON_AI_HUB_REPO_URL` and `LEMON_AI_HUB_REF`.
+
 ### Marketplace & Maintenance Scripts
 - `validate_plugins.py`: Checks every plugin against the canonical cross-harness layout. Source of truth for what a valid plugin is. Exits non-zero on any violation, so it works as a CI gate.
 - `normalize_plugins.py`: Repairs violations the validator reports — moves flat `skills/<n>.md` into `skills/<n>/SKILL.md`, derives a missing root `SKILL.md`, generates `plugin.json`, and fixes frontmatter `name`. Idempotent.

--- a/scripts/add-skill.sh
+++ b/scripts/add-skill.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# add-skill.sh - Install one Lemon AI Hub skill with the skills CLI.
+# Usage: ./scripts/add-skill.sh <skill-name> [skills add options]
+
+set -euo pipefail
+
+REPO_URL="${LEMON_AI_HUB_REPO_URL:-https://github.com/Andersonlimahw/lemon-ai-hub}"
+REPO_REF="${LEMON_AI_HUB_REF:-main}"
+
+usage() {
+  echo "Usage: $0 <skill-name> [skills add options]"
+  echo ""
+  echo "Install one skill from Lemon AI Hub via npx skills add."
+  echo "Example: $0 logo-creator-expert --global --yes --agent claude-code"
+}
+
+if [ "$#" -lt 1 ] || [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  [ "$#" -lt 1 ] && exit 1
+  exit 0
+fi
+
+skill_name="$1"
+shift
+
+if [[ ! "$skill_name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  echo "Error: skill name must be lowercase kebab-case: $skill_name" >&2
+  exit 2
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "Error: npx is required to install a skill." >&2
+  exit 127
+fi
+
+skill_source="${REPO_URL%/}/tree/${REPO_REF}/plugins/${skill_name}"
+exec npx skills add "$skill_source" "$@"

--- a/scripts/harness-doctor.sh
+++ b/scripts/harness-doctor.sh
@@ -17,6 +17,10 @@ link_is() { # $1=link $2=expected_target
   [ -L "$1" ] && [ "$(readlink "$1")" = "$2" ]
 }
 
+curated_overlay_is_ready() {
+  [ -d "$1" ] && [ -d "$HOME/.agents/skills" ] && [ -r "$HOME/.agents/skills/design-expert/SKILL.md" ]
+}
+
 echo "=== harness-doctor — $(date +%F) ==="
 
 echo "[hub]"
@@ -37,7 +41,16 @@ for f in CLAUDE.md RTK.md kaparthy.md settings.json; do
   [ -r "$HOME/.claude/$f" ] && ok "$f" || bad "$f missing"
 done
 if [ -e "$HOME/.claude/skills" ]; then
-  warn "~/.claude/skills exists — duplicates marketplace skills; remove it (design: lemon-ai-hub marketplace covers the hub)"
+  CLAUDE_DRIFT=0
+  for entry in "$HOME/.claude/skills"/*/; do
+    [ -d "$entry" ] || continue
+    n="$(basename "$entry")"
+    if [ -d "$HUB/$n" ]; then
+      warn "~/.claude/skills/$n duplicates marketplace skill"
+      CLAUDE_DRIFT=1
+    fi
+  done
+  [ "$CLAUDE_DRIFT" = "0" ] && ok "~/.claude/skills contains local-only skills"
 else
   ok "~/.claude/skills absent (correct: marketplace covers the hub)"
 fi
@@ -47,12 +60,24 @@ grep -q 'ctx-recall.sh' "$HOME/.claude/settings.json" && ok "ctx-recall (memory 
 grep -q 'auto-model-selector.sh' "$HOME/.claude/settings.json" && ok "auto-model-selector on UserPromptSubmit" || warn "auto-model-selector not wired"
 
 echo "[codex ~/.codex]"
-link_is "$HOME/.codex/skills" "$HUB" && ok "skills → hub" || bad "skills symlink wrong: $(readlink "$HOME/.codex/skills" 2>/dev/null || echo absent)"
+if link_is "$HOME/.codex/skills" "$HUB"; then
+  ok "skills → hub"
+elif curated_overlay_is_ready "$HOME/.codex/skills"; then
+  ok "curated skills + shared design-expert overlay"
+else
+  bad "skills topology wrong: $(readlink "$HOME/.codex/skills" 2>/dev/null || echo absent)"
+fi
 [ -r "$HOME/.codex/AGENTS.md" ] && ok "AGENTS.md" || bad "AGENTS.md missing"
 [ -r "$HOME/.codex/RTK.md" ] && ok "RTK.md" || warn "RTK.md missing (referenced by AGENTS.md)"
 
 echo "[agy ~/.agy]"
-link_is "$HOME/.agy/skills" "$HUB" && ok "skills → hub" || bad "skills symlink wrong: $(readlink "$HOME/.agy/skills" 2>/dev/null || echo absent)"
+if link_is "$HOME/.agy/skills" "$HUB"; then
+  ok "skills → hub"
+elif curated_overlay_is_ready "$HOME/.agy/skills"; then
+  ok "curated skills + shared design-expert overlay"
+else
+  bad "skills topology wrong: $(readlink "$HOME/.agy/skills" 2>/dev/null || echo absent)"
+fi
 [ -r "$HOME/.agy/AGENTS.md" ] && ok "AGENTS.md" || bad "AGENTS.md missing"
 
 echo "[opencode ~/.config/opencode]"

--- a/scripts/setup-symlinks.sh
+++ b/scripts/setup-symlinks.sh
@@ -85,13 +85,11 @@ echo "Target: All Supported Agents"
 # Claude Code deliberately has NO ~/.claude/skills link: it consumes the hub via
 # the lemon-ai-hub plugin marketplace; a skills/ symlink would duplicate every
 # skill in the session context.
-install_symlink "$REPO_PLUGINS_DIR" "~/.codex/skills"
-install_symlink "$REPO_PLUGINS_DIR" "~/.agy/skills"
 
-# OpenCode (~/.config/opencode) and Gemini keep CURATED skills dirs: hub-backed
-# entries become individual symlinks (fresh content, no drift), non-hub entries
-# are left untouched. Whole-dir symlinks would load 150+ skill descriptions per
-# session in those harnesses.
+# Codex, Agy, OpenCode (~/.config/opencode), and Gemini keep CURATED skills
+# dirs: hub-backed entries become individual symlinks, non-hub entries remain
+# untouched. Whole-dir symlinks would load 150+ descriptions per session and
+# would hide shared-overlay companions such as impeccable and revenue-centric-design.
 curate_hub_symlinks() {
   local skills_dir="$1"
   skills_dir="${skills_dir/#\~/$HOME}"
@@ -108,6 +106,8 @@ curate_hub_symlinks() {
     fi
   done
 }
+curate_hub_symlinks "~/.codex/skills"
+curate_hub_symlinks "~/.agy/skills"
 curate_hub_symlinks "~/.config/opencode/skills"
 curate_hub_symlinks "~/.gemini/skills"
 


### PR DESCRIPTION
## Resumo

- adiciona `logo-creator-expert` como plugin cross-harness do Lemon AI Hub;
- preserva a `SKILL.md` de referência byte-for-byte em `plugins/logo-creator-expert/`;
- registra o plugin no `.claude-plugin/marketplace.json` e regenera a tabela do `README.md`;
- documenta o fluxo em `scripts/README.md` e `docs/cli-marketplace.md`;
- adiciona `scripts/add-skill.sh` para instalar somente uma skill usando `npx skills add`.

## O que a skill entrega

`logo-creator-expert` orienta a criação de marcas minimalistas de um único gesto, derivadas do mecanismo real do produto e testadas em tamanhos reais. O processo cobre:

1. leitura da marca, tokens, tipografia e pontos de consumo antes do desenho;
2. geração de 4–6 conceitos distintos e seleção por conceito nomeável;
3. contact sheet real em fundos claro/escuro e revisão de legibilidade;
4. validação sem padding em 16/24/32/48px;
5. pacote de entrega com SVG editável, marca transparente, tile de app, ladder de tamanhos e favicon quando aplicável;
6. verificação no app real, incluindo cache agressivo de favicon/assets.

Também inclui framing revenue-centric e anti-patterns para evitar marcas genéricas, ornamentadas ou dependentes de gradiente.

## Instalação de uma única skill

O helper usa a URL direta do diretório do plugin para limitar a descoberta a uma skill:

```bash
./scripts/add-skill.sh logo-creator-expert --global --yes --agent claude-code
```

Equivalente direto:

```bash
npx skills add https://github.com/Andersonlimahw/lemon-ai-hub/tree/main/plugins/logo-creator-expert --global --yes
```

`LEMON_AI_HUB_REPO_URL` e `LEMON_AI_HUB_REF` permitem apontar o helper para outro fork ou branch.

## Verificação

- `python3 scripts/validate_plugins.py --plugin logo-creator-expert`: 0 erros, 0 warnings;
- `python3 scripts/validate_plugins.py --severity error`: 165 plugins, 0 erros, 0 warnings;
- `python3 -m unittest discover -s scripts/tests`: 54 testes passando;
- `bash -n scripts/add-skill.sh`: passou;
- `npx skills add ./plugins/logo-creator-expert --list`: encontrou exatamente 1 skill;
- instalação isolada em diretório temporário com `npx skills add ... --skill logo-creator-expert --copy --agent codex --yes`: instalou exatamente 1 skill;
- `SKILL.md` versionada comparada byte-for-byte com `~/.claude/skills/logo-creator-expert/SKILL.md`;
- manifesto sincronizado: 165 diretórios em `plugins/` e 165 entradas no marketplace, em ordem alfabética;
- `git diff --check`: passou.

## Escopo

Não foram gerados assets de logo: este plugin é uma skill procedural para orientar trabalhos de logo em projetos consumidores. Nenhum arquivo `.claude/` ou artefato de teste foi incluído.
