### PR TITLE
fix(code-review-expert): declare agents as an explicit array in plugin.json

### DIFF
--- a/plugins/code-review-expert/plugin.json
+++ b/plugins/code-review-expert/plugin.json
@@ -31,5 +31,8 @@
     "automation"
   ],
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": [
+    "./agents/thermo-nuclear-review-subagent.md",
+    "./agents/thermo-nuclear-code-quality-review-subagent.md"
+  ]
 }


### PR DESCRIPTION
## Problem

`code-review-expert` was impossible to install in Claude Code and Codex. `plugin.json` declared:

```json
"agents": "./agents/"
```

Claude Code's plugin manifest schema rejects a bare directory string for `agents`:

```
✘ Failed to install plugin "code-review-expert@lemon-ai-hub":
  Plugin ... has an invalid manifest file at .../plugin.json.
  Validation errors: agents: Invalid input
```

Because the install aborts on manifest validation, none of the plugin's components ever reached the harness — `code-review-expert`, `code-review-adversary`, `thermo-nuclear-review` and `thermo-nuclear-code-quality-review` were all silently missing, along with both subagents.

Antigravity was unaffected because it reads `SKILL.md` straight from the skill directory and never parses `plugin.json`, which is why the skill appeared to work there and nowhere else.

## Fix

Declare the two subagents as an explicit array of file paths:

```json
"agents": [
  "./agents/thermo-nuclear-review-subagent.md",
  "./agents/thermo-nuclear-code-quality-review-subagent.md"
]
```

## Verification

- `python3 scripts/validate_plugins.py` → `166 plugins checked — 0 errors, 0 warnings`
- `claude plugin install code-review-expert@lemon-ai-hub` → succeeds; all 4 skills + 2 agents land in the cache
- `codex plugin add code-review-expert@lemon-ai-hub` → `installed, enabled 1.0.0`
- `scripts/harness-doctor.sh` → `30 OK / 2 WARN / 0 FAIL` (both warnings pre-existing and unrelated)

## Known follow-up (not in this PR)

Four other plugins carry the same invalid `"agents": "./agents/"` manifest and fail to install for the same reason: `smart-sub-agents`, `continual-learning`, `agent-sdk-dev`, `task-interrogator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
