### PR TITLE
fix(plugins): declare agents as explicit arrays in four more manifests

### DIFF
--- a/plugins/agent-sdk-dev/plugin.json
+++ b/plugins/agent-sdk-dev/plugin.json
@@ -12,6 +12,5 @@
     "lemon-ai-hub",
     "agent-sdk-dev"
   ],
-  "skills": "./skills/",
-  "agents": "./agents/"
+  "skills": "./skills/"
 }

--- a/plugins/continual-learning/plugin.json
+++ b/plugins/continual-learning/plugin.json
@@ -26,7 +26,9 @@
     "memory",
     "transcripts"
   ],
-  "agents": "./agents/",
+  "agents": [
+    "./agents/agents-memory-updater.md"
+  ],
   "skills": "./skills/",
   "hooks": "./hooks/hooks.json"
 }

--- a/plugins/smart-sub-agents/plugin.json
+++ b/plugins/smart-sub-agents/plugin.json
@@ -21,5 +21,7 @@
     "antigravity",
     "gemini"
   ],
-  "agents": "./agents/"
+  "agents": [
+    "./agents/smart-route.md"
+  ]
 }

--- a/plugins/task-interrogator/plugin.json
+++ b/plugins/task-interrogator/plugin.json
@@ -29,6 +29,5 @@
     "validation",
     "productivity"
   ],
-  "skills": "./skills/",
-  "agents": "./agents/"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
Follow-up to #32, which fixed the same defect in `code-review-expert`.

## Problem

Four more plugins declared `agents` as a bare directory string:

```json
"agents": "./agents/"
```

Claude Code's plugin manifest schema rejects that shape, so every install aborted before any component was registered:

```
✘ Failed to install plugin "smart-sub-agents@lemon-ai-hub":
  Validation errors: agents: Invalid input
```

Affected: `smart-sub-agents`, `continual-learning`, `agent-sdk-dev`, `task-interrogator`.

`smart-sub-agents` is the worker-matrix plugin referenced by the shared `CLAUDE.md` routing contract, so its absence silently degraded agent dispatch across harnesses.

## Fix

Plugins that actually ship agents now list them explicitly:

- `smart-sub-agents` → `["./agents/smart-route.md"]`
- `continual-learning` → `["./agents/agents-memory-updater.md"]`

Plugins whose `agents/` directory is empty (`agent-sdk-dev`) or holds only a `.gitkeep` (`task-interrogator`) drop the `agents` key entirely rather than declaring a component set they do not provide.

## Verification

- `python3 scripts/validate_plugins.py` → `166 plugins checked — 0 errors, 0 warnings`
- `claude plugin install <name>@lemon-ai-hub` → succeeds for all four

🤖 Generated with [Claude Code](https://claude.com/claude-code)
