### PR TITLE
fix(plugins): drop dead skills paths and guard manifest declarations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,11 @@ the affected areas:
 - [`docs/rules/marketplace-sync.md`](docs/rules/marketplace-sync.md) — every plugin
   in `plugins/` MUST be registered in `.claude-plugin/marketplace.json` in the same
   change. Never add/rename/remove a plugin without syncing the marketplace.
+- [`docs/rules/plugin-manifest.md`](docs/rules/plugin-manifest.md) — never declare a
+  component path `plugin.json` cannot deliver. `agents` MUST be an array of file
+  paths (`"./agents/"` makes the whole install fail), and every declared `skills`
+  / `commands` / `hooks` path MUST exist. Prefer omitting the field: components
+  are discovered by convention. Verify with `python3 scripts/validate_plugins.py`.
 - [`docs/rules/worktree-hygiene.md`](docs/rules/worktree-hygiene.md) — `.claude/`
   is local machine state and MUST be in `.gitignore`. Before any `git commit` /
   `git push` / PR creation, run `rtk git worktree list` and remove every stale

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,12 @@ plugins/cli-wrapper/        ← CANONICAL SOURCE (git)
 └── templates/              ← symlink-map.json + config templates
 ```
 
+**`plugin.json` component fields** — see [`docs/rules/plugin-manifest.md`](docs/rules/plugin-manifest.md). Claude Code validates the manifest *before* registering anything, so one bad field silently removes every skill and agent the plugin ships:
+- `agents` MUST be an array of file paths. `"agents": "./agents/"` fails with `agents: Invalid input` and the plugin never installs — it stays invisible in Claude Code and Codex while still working in Antigravity, which never parses `plugin.json`.
+- Every declared `skills` / `commands` / `hooks` path MUST exist and be non-empty.
+- **Prefer omitting these fields.** Components are discovered by convention from `agents/`, `skills/` and the root `SKILL.md`; 158 of 166 plugins here declare nothing.
+- Verify before committing: `python3 scripts/validate_plugins.py` (MANIFEST_* codes) and `claude plugin validate plugins/<name>/plugin.json`.
+
 **Global topology** (managed by `scripts/setup-symlinks.sh`; verified by `scripts/harness-doctor.sh`):
 - Skills hub = this project's `plugins/`. Claude consumes it via the `lemon-ai-hub` plugin marketplace (no `~/.claude/skills` — it would duplicate every skill).
 - Codex/Agy: `~/.codex/skills` and `~/.agy/skills` → dir symlinks to `plugins/`

--- a/docs/rules/plugin-manifest.md
+++ b/docs/rules/plugin-manifest.md
@@ -1,0 +1,71 @@
+---
+title: plugin.json Component Declarations (MANDATORY)
+status: active
+updated: 2026-09-05
+related: [docs/rules/marketplace-sync.md, scripts/validate_plugins.py, AGENTS.md]
+---
+
+# Rule: never declare a component path `plugin.json` cannot deliver
+
+**Why:** PRs #32 and #33. Six plugins declared `"agents": "./agents/"`. Claude
+Code's manifest schema rejects a bare directory string there, and it validates
+the manifest **before** registering anything — so the install aborted and every
+skill and agent the plugin shipped vanished silently:
+
+```
+✘ Failed to install plugin "code-review-expert@lemon-ai-hub":
+  Validation errors: agents: Invalid input
+```
+
+The failure is invisible until someone tries to use the skill. `code-review-expert`
+was unreachable in Claude Code and Codex for months while working fine in
+Antigravity, which reads `SKILL.md` off disk and never parses `plugin.json`.
+`smart-sub-agents` — the worker-matrix plugin the routing contract depends on —
+was dead the same way.
+
+## The invariant
+
+Every component path a manifest declares MUST exist on disk, and `agents` MUST
+be an array.
+
+| Field      | Valid shape                                  | Invalid                     |
+|------------|----------------------------------------------|-----------------------------|
+| `agents`   | array of file paths                          | `"./agents/"` — install fails |
+| `skills`   | path to an existing, non-empty directory      | path that does not exist    |
+| `commands` | path to an existing, non-empty directory      | path that does not exist    |
+| `hooks`    | path to an existing file                      | path that does not exist    |
+
+```jsonc
+// correct
+"agents": [
+  "./agents/thermo-nuclear-review-subagent.md",
+  "./agents/thermo-nuclear-code-quality-review-subagent.md"
+]
+```
+
+## Prefer omitting the field
+
+Components are discovered by convention from `agents/`, `skills/` and the root
+`SKILL.md`. 158 of the 166 plugins in this repo declare no component fields at
+all and load correctly. **Declare a field only when you need to override the
+convention.** An omitted field cannot break; a wrong one takes the whole plugin
+down.
+
+Never declare a directory that is empty or holds only `.gitkeep` — that
+announces components the plugin does not ship.
+
+## How to verify before committing
+
+```bash
+# Repo guard — catches every shape above (MANIFEST_* codes):
+python3 scripts/validate_plugins.py
+
+# Claude Code's own schema, the authoritative oracle:
+for f in plugins/*/plugin.json; do claude plugin validate "$f"; done
+```
+
+`scripts/validate_plugins.py` reported `0 errors` while five plugins were
+uninstallable, which is why it now enforces this rule directly. Do not weaken
+the `MANIFEST_AGENTS_NOT_ARRAY`, `MANIFEST_PATH_NOT_FOUND` or
+`MANIFEST_PATH_EMPTY` checks — re-run `claude plugin validate` first and fix
+the manifest instead.

--- a/plugins/continual-learning/plugin.json
+++ b/plugins/continual-learning/plugin.json
@@ -29,6 +29,5 @@
   "agents": [
     "./agents/agents-memory-updater.md"
   ],
-  "skills": "./skills/",
   "hooks": "./hooks/hooks.json"
 }

--- a/plugins/task-interrogator/plugin.json
+++ b/plugins/task-interrogator/plugin.json
@@ -28,6 +28,5 @@
     "design",
     "validation",
     "productivity"
-  ],
-  "skills": "./skills/"
+  ]
 }

--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -160,6 +160,68 @@ def check_skill_file(report: Report, plugin: str, path: Path, expected_name: str
         )
 
 
+def check_component_declarations(report: Report, plugin_dir: Path, data: dict) -> None:
+    """Validate the optional component fields of plugin.json.
+
+    Claude Code refuses to install a plugin whose manifest fails schema
+    validation, and it aborts before registering any component — so one bad
+    field silently removes every skill and agent the plugin ships. Two shapes
+    have bitten this repo:
+
+        "agents": "./agents/"     -> `agents: Invalid input`, install fails
+        "skills": "./skills/"     -> accepted, but a load failure at runtime
+                                     when the directory does not exist
+
+    `agents` must be an array of file paths. Every declared path must exist.
+    Omitting a field entirely is always safe: components are discovered by
+    convention from agents/, skills/ and the root SKILL.md.
+    """
+    plugin = plugin_dir.name
+
+    agents = data.get("agents")
+    if isinstance(agents, str):
+        report.error(
+            plugin,
+            "MANIFEST_AGENTS_NOT_ARRAY",
+            f'plugin.json declares "agents": "{agents}" — Claude Code rejects a '
+            "bare directory string here (`agents: Invalid input`) and the whole "
+            "plugin fails to install. Use an array of file paths, or drop the "
+            "field and let agents/ be discovered by convention",
+        )
+        agents = None
+
+    declared: list[tuple[str, str]] = []
+    if isinstance(agents, list):
+        declared += [("agents", str(p)) for p in agents]
+    for key in ("skills", "commands", "hooks"):
+        value = data.get(key)
+        if isinstance(value, str):
+            declared.append((key, value))
+        elif isinstance(value, list):
+            declared += [(key, str(p)) for p in value]
+
+    for key, rel_path in declared:
+        target = (plugin_dir / rel_path).resolve()
+        if not target.exists():
+            report.error(
+                plugin,
+                "MANIFEST_PATH_NOT_FOUND",
+                f'plugin.json declares "{key}": "{rel_path}" but that path does '
+                "not exist — the runtime loader reports this as a load failure. "
+                "Fix the path or drop the field",
+            )
+        elif target.is_dir() and not any(
+            child for child in target.iterdir() if not child.name.startswith(".")
+        ):
+            report.warn(
+                plugin,
+                "MANIFEST_PATH_EMPTY",
+                f'plugin.json declares "{key}": "{rel_path}" but the directory is '
+                "empty — drop the field rather than announce components the "
+                "plugin does not ship",
+            )
+
+
 def check_plugin(report: Report, plugin_dir: Path) -> None:
     plugin = plugin_dir.name
 
@@ -190,6 +252,7 @@ def check_plugin(report: Report, plugin_dir: Path) -> None:
             report.error(plugin, "PLUGIN_JSON_NO_DESCRIPTION", "plugin.json has no description")
         if not data.get("version"):
             report.warn(plugin, "PLUGIN_JSON_NO_VERSION", "plugin.json has no version")
+        check_component_declarations(report, plugin_dir, data)
 
     # --- root SKILL.md ---------------------------------------------------
     root_skill = plugin_dir / "SKILL.md"


### PR DESCRIPTION
Closes out the defect class from #32 and #33: a `plugin.json` that declares a component path Claude Code cannot deliver.

## Full sweep

Ran Claude Code's own schema validator — the authoritative oracle — over all 166 manifests:

```bash
for f in plugins/*/plugin.json; do claude plugin validate "$f"; done
```

After #32 and #33, **one hard error remained**:

- `continual-learning` declared `"skills": "./skills/"`, but the plugin has no `skills/` directory — only a root `SKILL.md`. The validator reports `Path not found: ./skills/. The runtime loader will report this as a load failure.`

The new repo guard (below) then surfaced a second instance the CLI only warns about:

- `task-interrogator` declared `"skills": "./skills/"` pointing at a directory holding nothing but `.gitkeep`.

Both drop the field. Components are discovered by convention from `agents/`, `skills/` and the root `SKILL.md` — 158 of the 166 plugins here declare no component fields at all and load correctly.

No other manifest errors remain across the repo.

## Why this kept happening

`scripts/validate_plugins.py` reported `166 plugins checked — 0 errors, 0 warnings` the entire time five plugins were uninstallable. The repo's own gate could not see the defect, so nothing stopped it from landing — six times.

## Guard

`check_component_declarations()` in `scripts/validate_plugins.py` now enforces the invariant directly:

| Code | Severity | Catches |
|---|---|---|
| `MANIFEST_AGENTS_NOT_ARRAY` | ERROR | `"agents": "./agents/"` — the #32/#33 defect |
| `MANIFEST_PATH_NOT_FOUND` | ERROR | any declared `agents[]` / `skills` / `commands` / `hooks` path that does not exist |
| `MANIFEST_PATH_EMPTY` | WARN | a declared directory that is empty or `.gitkeep`-only |

Regression-tested by re-introducing each original defect into the working tree and confirming the guard fires:

```
ERROR MANIFEST_PATH_NOT_FOUND (2)
ERROR MANIFEST_AGENTS_NOT_ARRAY (1)
WARN  MANIFEST_PATH_EMPTY (1)
166 plugins checked — 3 errors, 1 warnings
```

Clean tree after restore: `166 plugins checked — 0 errors, 0 warnings`.

## Docs

- New rule `docs/rules/plugin-manifest.md`, following the existing `docs/rules/` convention, with the failure history and the "prefer omitting the field" guidance.
- Linked from `AGENTS.md` → Project Rules (the repo's single source of truth).
- `CLAUDE.md` gains the same invariant inline, next to the plugin-structure section where authors actually look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
