### PR TITLE
fix(setup-symlinks): refuse to curate a skills dir that resolves to the hub

### DIFF
--- a/scripts/setup-symlinks.sh
+++ b/scripts/setup-symlinks.sh
@@ -94,6 +94,19 @@ curate_hub_symlinks() {
   local skills_dir="$1"
   skills_dir="${skills_dir/#\~/$HOME}"
   [ -d "$skills_dir" ] || return 0
+
+  # A harness skills dir may itself be a whole-dir symlink to plugins/ (this is
+  # still the case for ~/.gemini/skills). Curating it would resolve straight
+  # into the hub and rewrite every plugins/<name> into a symlink pointing at
+  # itself, destroying the working tree. Compare physical paths, not the
+  # argument, and refuse to curate the hub into itself.
+  local resolved
+  resolved="$(cd "$skills_dir" 2>/dev/null && pwd -P)" || return 0
+  if [ "$resolved" = "$(cd "$REPO_PLUGINS_DIR" && pwd -P)" ]; then
+    echo "Skipping curate for $skills_dir — it resolves to the hub itself ($resolved)"
+    return 0
+  fi
+
   local entry name
   for entry in "$skills_dir"/*/; do
     [ -d "$entry" ] || continue


### PR DESCRIPTION
## What happened

Running `scripts/setup-symlinks.sh` replaced all 166 directories in this repo's own `plugins/` with symlinks pointing at themselves:

```
plugins/ads -> /Users/.../lemon-ai-hub/plugins/ads
```

Every plugin file became unreachable (`Too many levels of symbolic links`), including `git status`. Recovered from `HEAD` — the script does take backups (`plugins/.<name>_bak_<ts>`), and no content was lost, but the working tree was unusable until restored by hand.

## Root cause

`curate_hub_symlinks()` converts physical hub copies inside a harness skills dir into per-skill symlinks. It guards on `[ -d "$skills_dir" ]`, which follows symlinks.

`~/.gemini/skills` is a whole-dir symlink to the hub:

```
~/.gemini/skills -> /Users/.../lemon-ai-hub/plugins
```

So `curate_hub_symlinks "~/.gemini/skills"` iterated `plugins/*/` **inside the repo**. For each entry, `-L` was false (a real directory) and `$REPO_PLUGINS_DIR/$name` existed, so it moved the plugin aside and replaced it with `ln -s "$REPO_PLUGINS_DIR/$name"` — a link to the very path it had just emptied.

The function had no notion that its target might *be* the hub.

## Fix

Resolve the physical path of `skills_dir` and refuse to curate when it is the hub:

```sh
resolved="$(cd "$skills_dir" 2>/dev/null && pwd -P)" || return 0
if [ "$resolved" = "$(cd "$REPO_PLUGINS_DIR" && pwd -P)" ]; then
  echo "Skipping curate for $skills_dir — it resolves to the hub itself ($resolved)"
  return 0
fi
```

`pwd -P` is used on both sides so the comparison is symlink-free and holds regardless of which harness dir is (or later becomes) a whole-dir symlink — `~/.agy/skills` and `~/.config/opencode/skills` are physical dirs today, but the same trap applies to them.

This deliberately does **not** re-plumb Gemini's topology. `~/.gemini/skills` staying a whole-dir symlink is the existing arrangement that `harness-doctor.sh` checks and reports OK; changing it is a separate decision.

## Verification

Reproduced the exact topology in a throwaway tree and ran the patched function against both cases:

```
### trap (gemini-style whole-dir symlink):
Skipping curate for .../home/gemini-skills — it resolves to the hub itself (.../hub/plugins)

### normal curated dir:
Curating: alpha (physical hub copy -> symlink)

### hub intact?
real dirs: 2   self-symlinks: 0
alpha content: a

### codex-skills/alpha became a symlink? yes
```

The hub survives the trap; ordinary curation is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
