### PR TITLE
feat(apple-skills): generalize field-observed App Store rejection learnings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1067,6 +1067,22 @@
       ]
     },
     {
+      "name": "graph-feature-architect",
+      "source": "./plugins/graph-feature-architect",
+      "description": "Plan new feature implementations grounded in the project's existing knowledge graph (graphify-out/ or a karpathy-graph output) instead of ad-hoc grepping. Use when the user asks to plan, scope, or architect a new feature and a graph already exists for the codebase — surfaces god nodes, community boundaries, and cross-file relationships the feature will touch before any code is written. Recreated as a minimal skeleton after the original plugin was removed from the hub; broken symlinks in consumer repos pointed here.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "skill",
+        "lemon-ai-hub",
+        "graph-feature-architect",
+        "knowledge-graph",
+        "feature-planning",
+        "architecture",
+        "graphify"
+      ]
+    },
+    {
       "name": "hatch-pet",
       "source": "./plugins/hatch-pet",
       "description": "Create, repair, validate, visually QA, and package Codex-compatible v2 animated pets from character art, generated images, company or prospect brand cues, or visual references. Use for any new Codex pet, custom mascot, non-pixel pet style, brand-inspired pet, existing-pet repair, or 8x11 spritesheet workflow requiring all 9 standard animation rows, 16 look directions, deterministic assembly, QA artifacts, and spriteVersionNumber 2 packaging.",

--- a/plugins/app-store-connect-api/SKILL.md
+++ b/plugins/app-store-connect-api/SKILL.md
@@ -18,5 +18,26 @@ It is composed of multiple specialized skills that cover the specific domains of
 ## Capabilities
 When tasked with an App Store Connect API operation, refer to the corresponding domain skill to access detailed endpoint paths, required parameters, and best practices.
 
+## What the API Can and Cannot Do
+
+Field-observed from real release/review cycles — the gap between "the OpenAPI spec has an endpoint" and "this is actually usable for the task" is the single most expensive thing to learn by trial and error. Re-check against Apple's current API reference before treating any row as a hard blocker; this surface changes.
+
+| Action | API? | Note |
+|---|---|---|
+| Read submission state, builds, IAPs, age rating | ✅ Yes | Read-only queries are safe to automate |
+| Age Rating declaration | ✅ `PATCH /v1/ageRatingDeclarations/{id}` | Confirm with the account owner before writing |
+| IAP / subscription localization (name, description) | ✅ `PATCH /v1/inAppPurchaseLocalizations/{id}` | Hard limits: display name 30 chars, description 45 chars |
+| Delete a promotional image | ✅ `DELETE /v1/promotedPurchaseImages/{id}` | Often simpler than authoring two visually distinct images |
+| Upload a promotional image | ⚠️ Yes, but 3-step (reserve → upload → commit) | The App Store Connect UI is faster for a one-off |
+| Upload App Store screenshots | ⚠️ Technically yes | Possible but painful; the UI's Media Manager is recommended |
+| **Read a crash log the reviewer attached** | ❌ No | `GET /v1/builds/{id}/diagnosticSignatures` returns empty for reviewer-attached reports — the attachment only exists in the Resolution Center UI |
+| **Read or reply to the Resolution Center thread** | ❌ No | No endpoint surfaces reviewer messages; UI only |
+| **Create a sandbox tester** | ❌ No | `POST /v1/sandboxTesters` returns `404 PATH_ERROR`; Users and Access UI only |
+| Submit for review / Update Review | ✅ Technically yes | 🚫 Never call without explicit, visible confirmation from the account owner — this is outward-facing and effectively irreversible |
+
+**Credential hygiene (non-negotiable):** the `.p8` private key, issuer ID, and key ID live outside any repo (e.g. `~/.config/asc/`), are `.gitignore`d (`*.p8`, `AuthKey_*.p8`, `credentials.env`), and generated JWTs (20-minute lifetime) are never logged or committed in plaintext. Scope the API key role to the minimum the task needs. On any suspected leak: revoke in App Store Connect, recreate, rotate.
+
+For the official human-contact channels when the API and the Resolution Center both fall short (there is no direct email or executive contact), see `app-store-review`'s field lessons.
+
 ## OpenAPI Reference
 The agent derives its knowledge from the official App Store Connect OpenAPI specification. Always ensure requests match the expected payload structure defined in the `openapi.oas.json`.

--- a/plugins/app-store-review/SKILL.md
+++ b/plugins/app-store-review/SKILL.md
@@ -97,11 +97,14 @@ These are rejections that actually occurred across five consecutive review cycle
 3. **iPad is the review device.** Every finding in that timeline came from an iPad Air 11-inch. Several bugs reproduced *only* there (sheet animation races, release-build event batching). iPhone-only testing is not coverage.
 4. **Release builds behave differently.** The auth bug was invisible in dev builds; JS bridge batching changed native event ordering. Smoke-test a release/TestFlight build.
 5. **Verify the reviewed binary contains the fix.** One rejection repeated purely because the reviewed build predated the fix commit. A fix on `main` proves nothing about the binary Apple tested.
+6. **A citation does not mean the fix is in the codebase.** One 2.3.10 rejection was an App Store Connect IAP localization field, not app code — the repo was already clean with a passing regression spec. Audit App Store Connect metadata directly before assuming the fix is a code change.
+7. **One static regression test per closed finding.** A finding without a test that would have caught it comes back — either as a regression, or as the same bug class on a screen nobody thought to re-check (an unlinked-but-reachable route repeated a sheet-race bug for exactly this reason).
 
 ### High-frequency root causes
 
 | Guideline | Failure | Root cause | Gate |
 |---|---|---|---|
+| 2.1 | Crash on launch, no JS stack trace | recently added native module imported at top-of-file; `requireNativeModule` runs at import time, before the root component mounts | cold-launch 5× in a **Release** build; move the import behind a function-scoped dynamic import |
 | 2.1(a) | Button does nothing | `accessibilityRole="button"` with no `onPress` | grep for interactive elements missing a handler |
 | 2.1(a) | "Rate app" inert | native review prompt is a silent no-op in review builds and rate-limited | always fall back to the App Store product page URL |
 | 2.1(a) | Confirmation never appears | nested confirmation sheets race the first sheet's dismissal on iPad | one confirmation at a time |
@@ -111,6 +114,7 @@ These are rejections that actually occurred across five consecutive review cycle
 | 2.3.2 | Duplicate IAP metadata | display name/description identical across products, per locale | diff every product × locale pair |
 | 2.3.6 | Age rating overclaims | declared a control the reviewer could not find | set to `None` unless the feature is front-and-center |
 | 2.3.3 / 2.3.10 | Screenshots | marketing mockups, non-iOS status bars, stale slots | capture from the candidate build; audit via View All Sizes in Media Manager |
+| 2.3.10 | Cites a competing platform, code is clean | the flagged text is an App Store Connect **IAP localization** field, not app code | audit ASC IAP localizations per product/locale before touching the repo |
 | 5.1.1(iv) | Permission copy | pre-permission button said "Grant Permission" | use "Continue" / "Next"; change `accessibilityLabel` too |
 | 5.1.1(ix) | Account type | individual enrollment for a regulated-category app | not fixable in code — resolve enrollment first |
 | 4.8 | Login services | third-party login without an equivalent privacy-preserving option | add Sign in with Apple |
@@ -120,7 +124,7 @@ These are rejections that actually occurred across five consecutive review cycle
 - **Paid Applications Agreement must be `Active`** — pending banking or tax means no purchase works, including the reviewer's.
 - **Build numbers are monotonic and single-use** — verify the last accepted build via the App Store Connect API before submitting.
 - **`npm ci` fails on any lockfile drift** — regenerate the lock on the CI Node major and commit both files together.
-- **Four distinct states, routinely conflated:** cloud build finished ≠ submit processed ≠ build attached to the version ≠ Update Review submitted.
+- **Five distinct states, routinely conflated:** cloud build finished ≠ submit processed ≠ TestFlight Ready to Submit ≠ build attached to the version ≠ Update Review submitted.
 - **Sandbox testers cannot be created via the API** (`404 PATH_ERROR`) — App Store Connect UI only.
 - **Stop before `Update Review`** and get explicit owner confirmation. Same for replying to the reviewer and releasing.
 
@@ -353,6 +357,8 @@ All rejections appear in the **Resolution Center** in App Store Connect. To resp
 4. If you believe the rejection is incorrect, explain why your app complies, with references to the specific guideline text.
 
 **Tone matters.** Be professional, specific, and concise. Provide demo credentials, screenshots, or screen recordings that demonstrate compliance. Avoid emotional language or threats.
+
+There is no direct email or executive contact channel — see [references/field-lessons-rn-expo.md#apple-contact-channels](references/field-lessons-rn-expo.md#apple-contact-channels) for the three official paths (Resolution Center, App Review Appeal, Developer Support) in escalation order.
 
 ### Escalation to App Review Board
 

--- a/plugins/app-store-review/references/field-lessons-rn-expo.md
+++ b/plugins/app-store-review/references/field-lessons-rn-expo.md
@@ -5,6 +5,7 @@ Rejection patterns observed across five consecutive App Review cycles on a produ
 ## Contents
 
 - [Rejection Timeline](#rejection-timeline)
+- [2.1 — Crash on Launch from Import-Time Native Module](#21--crash-on-launch-from-import-time-native-module)
 - [2.1(a) — Dead Interactive Elements](#21a--dead-interactive-elements)
 - [2.1(a) — Login Loop from Auth Listener Null-Flash](#21a--login-loop-from-auth-listener-null-flash)
 - [2.1(b) — Entitlement Locked After Sandbox Purchase](#21b--entitlement-locked-after-sandbox-purchase)
@@ -13,14 +14,17 @@ Rejection patterns observed across five consecutive App Review cycles on a produ
 - [2.3.2 — Duplicate IAP Metadata and Promo Images](#232--duplicate-iap-metadata-and-promo-images)
 - [2.3.6 — Age Rating Declares Features That Do Not Exist](#236--age-rating-declares-features-that-do-not-exist)
 - [2.3.10 / 2.3.3 — Screenshots](#2310--233--screenshots)
+- [2.3.10 — IAP Localization Referencing Another Platform](#2310--iap-localization-referencing-another-platform)
 - [5.1.1(iv) — Pre-Permission Button Copy](#511iv--pre-permission-button-copy)
 - [5.1.1(ix) — Individual vs Organization Enrollment](#511ix--individual-vs-organization-enrollment)
 - [4.8 — Login Services Equivalence](#48--login-services-equivalence)
 - [1.5 — Support URL Must Actually Support](#15--support-url-must-actually-support)
 - [3.1.2 — Terms of Use / EULA Link](#312--terms-of-use--eula-link)
+- [Investigation Methodology](#investigation-methodology)
 - [Build, Version, and Submission Pipeline](#build-version-and-submission-pipeline)
 - [iPad Is the Review Device](#ipad-is-the-review-device)
 - [App Store Connect API — What It Can and Cannot Do](#app-store-connect-api--what-it-can-and-cannot-do)
+- [Apple Contact Channels](#apple-contact-channels)
 - [Pre-Submission Gate Script](#pre-submission-gate-script)
 
 ---
@@ -37,6 +41,31 @@ Five cycles on one app. The pattern to internalize: **each fix surfaced the next
 | Aug 18, 2026 | 2.3.2 ×2, 2.3.6, 3.1.2(c), 2.1(b), 2.1(a), 5.1.1(iv) | Duplicate IAP metadata; price hierarchy; entitlement locked; dead buttons; permission copy |
 
 **Meta-lesson:** the same guideline was cited across cycles for *different* root causes (2.1(a) was first an auth bug, later a missing `onPress`). Never assume a repeat citation means the previous fix regressed — re-diagnose from scratch.
+
+---
+
+## 2.1 — Crash on Launch from Import-Time Native Module
+
+**What happened:** the app died on cold start with no JS stack trace, no crash the debug build reproduced, and no error the boot-time `try/catch` guard ever saw. The misleading symptom pointed everyone at "SDK/OS too new" for two rounds before the real cause surfaced.
+
+**Root cause:** a newly added native package (`expo-*` / `react-native-*`) was imported at the **top of a file** with a static `import` (or a top-level `require()`). Metro's bundle executes every top-level `require()` in the module graph before the root component ever mounts. If that native module's `requireNativeModule` call fails at **import time** — missing native build step, config plugin not applied, native module not linked in the binary that was actually shipped — the process dies before React even renders, which means it also dies **before any JS-level error boundary or boot guard can run.**
+
+```ts
+// REJECTED — requireNativeModule() runs the instant this file is imported,
+// anywhere in the module graph, including from an unrelated screen's import chain
+import { SomeNativeModule } from "expo-some-new-native-package";
+
+// CORRECT — the native call only runs when the feature is actually used,
+// inside a function, after the root component has mounted
+async function useSomeNativeFeature() {
+  const { SomeNativeModule } = await import("expo-some-new-native-package");
+  return SomeNativeModule.doThing();
+}
+```
+
+**Generalize:** any native module added recently is a suspect for import-time failure, independent of how carefully the JS around it is guarded. `require()`/`import` inside a function defers the native call to actual usage; a top-level import runs unconditionally for every user, on every launch, even on screens that never call the feature.
+
+**Gate:** cold launch the app 5× in a **Release** build (Debug/dev-client builds frequently don't reproduce this — different bundling and native linking). A crash that only appears in Release, with zero JS stack trace, on a recently-added native dependency, is this bug until proven otherwise.
 
 ---
 
@@ -72,6 +101,8 @@ if (await StoreReview.hasAction()) {
 Treat "nothing visible happened" as a failing state: surface a snackbar rather than returning silently.
 
 **Related trap — nested confirmation sheets race on iPad.** Two chained `confirmAction()` calls (second fired inside the first's `onConfirm`) raced against the first sheet's dismissal animation. On iPhone it worked; on iPad's larger layout and different animation timing, the second sheet never rendered — "Delete account" appeared dead. Use one confirmation at a time (explicit step state, or a single sheet with the irreversible copy inline). Apple does not require double confirmation — only that deletion *works*.
+
+**Related trap — orphan routes reappear.** A route was registered in the navigator's route table but not linked from any visible entry point (leftover from a removed flow, or a screen built ahead of its trigger). It carried the *same* nested-sheet bug as above, and because nothing pointed at it, the fix that closed the bug on the reachable screens never touched it — it resurfaced in the next review cycle. A route that exists is reachable by definition (deep link, accessibility scanning, or a future PR wiring it up); "nobody uses this screen today" is not the same as "nobody can reach this screen." When closing a bug class (dead handler, unsafe pattern, banned wording), grep the **whole route table**, not just the screens currently linked in a tab bar or stack.
 
 ---
 
@@ -214,6 +245,18 @@ Two separate rejections, both about screenshots:
 
 ---
 
+## 2.3.10 — IAP Localization Referencing Another Platform
+
+**What happened:** a rejection cited 2.3.10 and quoted text that referenced a competing platform by name. The code had already been audited clean for that exact wording, with a regression spec passing. The bug was not in the repository at all.
+
+**Root cause:** the flagged text lived in an **In-App Purchase localization** field in App Store Connect (product display name or description), not in any app string, locale file, or bundled asset. A prior product-description pass had left it there; nothing in the codebase could have caught it because nothing in the codebase renders it — App Store Connect serves it directly to App Review and to the storefront.
+
+**Generalize:** a citation of guideline 2.3.x, 2.1, or similar does not imply the fix is in the repository. Metadata surfaces that live entirely in App Store Connect — IAP localizations, app description, promotional text, keywords, review notes, age rating answers — are frequently the actual source, and a clean codebase plus a green regression suite proves nothing about them.
+
+**Fix:** audit every IAP/subscription localization (per product, per locale) in App Store Connect directly before touching a single line of code. `PATCH /v1/inAppPurchaseLocalizations/{id}` fixes it once located; the API can also `GET` every localization for a product to search across them without opening each one manually in the UI.
+
+---
+
 ## 5.1.1(iv) — Pre-Permission Button Copy
 
 **What happened:** the custom pre-permission screen before the camera prompt had a button labeled "Grant Permission" / "Conceder Permissão". Apple's instruction was literal: *"Use words like 'Continue' or 'Next' on the button instead."*
@@ -284,9 +327,25 @@ curl -sS -o /dev/null -w "privacy: %{http_code}\n" -L https://example.com/privac
 
 ---
 
+## Investigation Methodology
+
+Process lessons from running this loop across five review cycles — as load-bearing as the individual bug fixes above.
+
+**Audit the current code before acting on the rejection text.** Apple reviewed a build that may be several commits, or several days, behind `main`. A commit that mentions the fix does not prove the shipped behavior is correct today; the rejection text describes what an old binary did, not necessarily what the current tree does. Reproduce (or confirm-fixed) against **current** code first, then decide whether the reviewer's finding is stale, still real, or was actually a different bug wearing the same guideline number.
+
+**Separate what code can prove from what only a human can prove.** Split remediation into two tracks per finding:
+- **Code-provable:** static analysis, typecheck, a regression test, a grep gate — anything a CI job can verify.
+- **Human-only:** a physical device (especially iPad), App Store Connect UI actions (Resolution Center replies, sandbox tester creation, screenshot slot uploads), signing an agreement, confirming a real sandbox purchase.
+
+A green typecheck or a passing unit suite never closes a finding whose proof requires a physical iPad or an App Store Connect screen. Track the two separately so "done" for the code track is never mistaken for "done" overall.
+
+**Write one static regression test per finding, not a general-purpose sweep.** Each closed finding gets a spec that would have caught it: an assertion that every `accessibilityRole="button"` element has a paired `onPress` in the same block; an assertion that no purchase-flow string mentions a competing marketplace; a check that a specific route is reachable from the navigator. A finding without a regression test is a finding that comes back — either as a regression on the same file, or as the same bug class on a file nobody thought to check (see the orphan-route trap above).
+
+---
+
 ## Build, Version, and Submission Pipeline
 
-**Four distinct states, routinely conflated.** "EAS build finished" ≠ "submit processed" ≠ "build attached to the App Store version" ≠ "Update Review submitted". Verify each one independently; a green EAS status proves only the first.
+**Five distinct states, routinely conflated.** "Cloud build finished" ≠ "submit processed" ≠ "TestFlight Ready to Submit" ≠ "build attached to the App Store version" ≠ "Update Review submitted". Verify each one independently; a green build status proves only the first, and reaching "Ready to Submit" in TestFlight does not by itself mean the build has been attached to the version under review. Never declare the release done at the first state.
 
 **Build numbers are monotonic and single-use.** Reusing one fails upload with `bundle version must be higher than previously uploaded version`. Confirm the last accepted build via the App Store Connect API before submitting:
 
@@ -330,9 +389,25 @@ Every rejection in this timeline was found on an **iPad Air 11-inch (M3)**. Revi
 | Upload a promo image | Three-step (reserve → upload → commit) | Painful; the App Store Connect UI is faster |
 | Upload App Store screenshots | Technically yes | Recommended: do it manually |
 | **Create sandbox testers** | **No** | `/v1/sandboxTesters` returns `404 PATH_ERROR`; UI only |
+| **Read the crash log a reviewer attached** | **No** | `GET /v1/builds/{id}/diagnosticSignatures` returns empty for reviewer-attached crash reports — the attachment only exists in the Resolution Center UI |
+| **Read or reply to the Resolution Center thread** | **No** | UI only; there is no endpoint that surfaces reviewer messages |
 | Submit for review | Yes | **Do not run without explicit owner confirmation** |
 
+Re-check this table against Apple's current API reference before treating any row as a hard blocker — API surface area changes without much notice.
+
 **Credential hygiene:** the `.p8` private key, issuer ID, and key ID live outside the repo (e.g. `~/.config/asc/`), are `.gitignore`d (`*.p8`, `AuthKey_*.p8`, `credentials.env`), and JWTs (20-minute lifetime) are never logged in plaintext or committed. Use the minimum API key role for the task. On leak: revoke in App Store Connect, recreate, rotate.
+
+---
+
+## Apple Contact Channels
+
+There is no direct email address and no channel to a human executive. The only official paths, in escalation order:
+
+1. **Resolution Center** inside App Store Connect — the thread attached to the specific submission; the default channel for replying to a rejection.
+2. **App Review Appeal** — `https://developer.apple.com/contact/request/app-review/appeal/` — for a rejection believed to be a misapplication of the guidelines, when the Resolution Center exchange did not resolve it.
+3. **Developer Support** — `https://developer.apple.com/contact/` — for account-level, enrollment, or tooling issues unrelated to a specific submission's review outcome.
+
+Re-verify these URLs against Apple's current developer site before relying on them; contact-form paths are metadata Apple can restructure.
 
 ---
 
@@ -351,6 +426,11 @@ rg -n "Grant Permission|Conceder Permissão|Otorgar Permiso" src/
 # Native alerts instead of in-app confirmation UI (review-flow reliability)
 rg -n "Alert\.(alert|prompt)" src/
 
+# Newly added native dependency imported at top-of-file (import-time crash risk)
+rg -n "^import .* from ['\"](expo-|react-native-)" src --glob '*.{ts,tsx}'
+# for every hit: confirm the package isn't newly added since the last release,
+# or move the import behind a function-scoped dynamic import
+
 # Terms / privacy reachable
 curl -sS -o /dev/null -w "terms: %{http_code}\n"   -L "$TERMS_URL"
 curl -sS -o /dev/null -w "privacy: %{http_code}\n" -L "$PRIVACY_URL"
@@ -364,6 +444,10 @@ npx vitest run                # suite green
 
 **Manual gates that no script covers:**
 
+- [ ] Cold-launched the Release build 5× (not Debug) — no crash, especially after adding a native dependency
+- [ ] Grepped the full route table (not just tab-bar/stack entries currently linked) for the bug class being closed
+- [ ] Audited App Store Connect metadata (IAP localizations, description, review notes) directly — a clean repo does not clear a metadata-sourced rejection
+- [ ] Every closed finding has a static regression test, not just a manual confirmation
 - [ ] Physical iPad, release/TestFlight build: login with **every** provider, session survives cold start
 - [ ] Physical iPad sandbox: monthly **and** annual purchase each unlock premium **without restart**
 - [ ] Paid Applications Agreement is `Active`
@@ -375,4 +459,5 @@ npx vitest run                # suite green
 - [ ] Screenshots captured from the candidate build, audited slot-by-slot in **View All Sizes in Media Manager**, all locales
 - [ ] Build number is higher than the last uploaded build (verified via API)
 - [ ] The fix commit is an ancestor of the submitted build's revision
+- [ ] All five pipeline states verified independently (build finished, submit processed, TestFlight Ready to Submit, build attached to the version, Update Review submitted) — not assumed from the first
 - [ ] Reviewer response drafted; **stop and get owner confirmation before `Update Review`**

--- a/plugins/apple-store-release-agent/README.md
+++ b/plugins/apple-store-release-agent/README.md
@@ -50,7 +50,9 @@ plugins/apple-store-release-agent/
     ├── validate-i18n-parity.mjs
     ├── validate-no-native-alerts.mjs
     ├── validate-revenuecat-iap.mjs
-    └── validate-privacy-readiness.mjs
+    ├── validate-privacy-readiness.mjs
+    ├── validate-static-native-imports.mjs
+    └── validate-missing-handlers.mjs
 ```
 
 ## Usage
@@ -70,6 +72,8 @@ Or run a validator directly (Node.js ≥ 18, zero deps):
 node scripts/validate-ios-release.mjs --project . --strict --json
 node scripts/validate-revenuecat-iap.mjs --project . --strict --json
 node scripts/validate-privacy-readiness.mjs --project . --strict --json
+node scripts/validate-static-native-imports.mjs --project . --strict --json
+node scripts/validate-missing-handlers.mjs --project . --strict --json
 ```
 
 Flags accepted by all scripts: `--project <path>` (default cwd), `--output <path>` (write report), `--strict`, `--json`.

--- a/plugins/apple-store-release-agent/SKILL.md
+++ b/plugins/apple-store-release-agent/SKILL.md
@@ -126,8 +126,12 @@ A run can only return **GO** when **all** hold:
 - [ ] Lockfile is in sync with the manifest and was regenerated on the CI Node major; `npm ci` is expected to pass
 - [ ] Build number is monotonic, single-use, and higher than the last uploaded build, verified through the App Store Connect API
 - [ ] The fix commit is an ancestor of the revision included in the candidate build
-- [ ] Four pipeline states are independently verified: cloud build finished, submit processed, build attached to the App Store version, and `Update Review`
+- [ ] Five pipeline states are independently verified: cloud build finished, submit processed, TestFlight Ready to Submit, build attached to the App Store version, and `Update Review`
 - [ ] The workflow stops before `Update Review` and waits for explicit account-owner confirmation
+- [ ] No `accessibilityRole="button"` element without a matching `onPress` (BLOCKER — this reliably triggers a 2.1(a) rejection)
+- [ ] No top-level import of a recently added native package without confirming it is import-time-safe (crash-on-launch risk; cold-launch a **Release** build 5× to check)
+- [ ] Every closed App Review finding has a corresponding static regression test — a finding without one comes back
+- [ ] Rejection text was cross-checked against **current** code and, where relevant, App Store Connect metadata (IAP localizations, description, review notes) — not assumed to be a code-only fix
 
 Any failed gate → at least `GO_WITH_WARNINGS`. Failed **security/legal** gates (secrets, gambling wording, missing account deletion) → `NO_GO`.
 
@@ -152,6 +156,8 @@ eas submit --platform ios --profile production --latest
 node plugins/apple-store-release-agent/scripts/validate-ios-release.mjs --project . --strict
 node plugins/apple-store-release-agent/scripts/validate-revenuecat-iap.mjs --project . --strict
 node plugins/apple-store-release-agent/scripts/validate-privacy-readiness.mjs --project . --strict
+node plugins/apple-store-release-agent/scripts/validate-static-native-imports.mjs --project . --strict
+node plugins/apple-store-release-agent/scripts/validate-missing-handlers.mjs --project . --strict
 ```
 
 Mark every submit/pay/publish line with `# REQUIRES EXPLICIT APPROVAL`.
@@ -206,6 +212,8 @@ Located in `scripts/`. Run them; collect JSON; map findings to severities. All a
 | `validate-no-native-alerts.mjs` | `Alert.alert` / `Alert.prompt` usages with file:line, suggests confirmation-sheet/snackbar abstraction |
 | `validate-revenuecat-iap.mjs` | public RC envs, product references, iOS product consistency, restore-purchases heuristic, paywall fallback risk |
 | `validate-privacy-readiness.mjs` | privacy policy + terms links, SDK data collection map, permission usage, suggested App Privacy labels (suggestion only — never auto-declare) |
+| `validate-static-native-imports.mjs` | top-of-file imports of `expo-*`/`react-native-*` packages — a broken native link on a top-level import crashes on launch before the root component mounts and before any boot-time try/catch runs; heuristic, confirm against the package's actual add date |
+| `validate-missing-handlers.mjs` | `accessibilityRole="button"` elements with no `onPress` in the surrounding block (BLOCKER — guaranteed 2.1(a) rejection), plus files with 2+ `confirmAction()` calls (nested confirmation sheets that race each other's dismiss animation, mainly on iPad) |
 
 Scripts **fail safe**: on a non-Expo repo they emit `INFO`/`WARNING` and exit 0 unless `--strict`.
 
@@ -218,6 +226,7 @@ Scripts **fail safe**: on a non-Expo repo they emit `INFO`/`WARNING` and exit 0 
 - Require `eas.json` with `production` build + submit profiles.
 - Verify `EXPO_PUBLIC_*` public envs are intentional; flag mock flags for prod.
 - Suggest `expo prebuild --clean` discipline and a version-bump check.
+- Flag top-level imports of recently added native packages (`expo-*`, `react-native-*`) — `requireNativeModule()` runs at Metro import-time, before the root component mounts, so a broken native link crashes on launch with no JS stack trace. Cold-launch a **Release** build 5× before every submission; this does not reproduce in Debug/dev-client builds.
 
 ### 12.2 Firebase
 - Detect `@react-native-firebase/*` or `expo-*` Firebase packages.

--- a/plugins/apple-store-release-agent/checklists/apple-review.md
+++ b/plugins/apple-store-release-agent/checklists/apple-review.md
@@ -4,7 +4,11 @@ Walk this checklist before any submission. Items marked ⚠️ BLOCKER force NO_
 
 ## App Completeness
 - [ ] App launches without crash on cold start
+- [ ] Cold-launched the **Release** build 5× — a recently added native package (`expo-*`/`react-native-*`) imported at top-of-file crashes on launch with no JS stack trace; Debug/dev-client builds do not reproduce this — ⚠️ BLOCKER if any recently added native package is imported statically
 - [ ] All primary flows functional (no "coming soon", no dead buttons)
+- [ ] No `accessibilityRole="button"` element without a matching `onPress` — ⚠️ BLOCKER (reliably triggers 2.1(a))
+- [ ] No destructive action wired to nested confirmation sheets (a second `confirmAction` fired from inside the first's `onConfirm`) — races the dismiss animation, mainly on iPad
+- [ ] The full route table was audited for the above two patterns, not just screens currently linked from a tab bar or stack — an unlinked-but-registered route is still reachable
 - [ ] No placeholder/lorem-ipsum content visible to users
 - [ ] No debug/staging menus reachable in prod build
 - [ ] `EXPO_PUBLIC_USE_MOCK` is NOT `true` in production env
@@ -47,6 +51,14 @@ Walk this checklist before any submission. Items marked ⚠️ BLOCKER force NO_
 - [ ] APP_STORE_REVIEW_NOTES.md populated (see templates/review-notes.md)
 - [ ] Special configurations flagged for reviewer (feature flags, env)
 
+## Rejection Response Discipline (if responding to a prior rejection)
+- [ ] Reproduced (or confirmed fixed) against **current** code, not just the commit that claims the fix — the reviewed build may be behind `main`
+- [ ] Checked whether the cited guideline is actually an App Store Connect metadata issue (IAP localization, description, review notes, age rating) before assuming it's a code change
+- [ ] Each finding split into code-provable (typecheck/test/grep) vs human-only (physical device, ASC UI, agreements, sandbox tester) — a green CI run does not close a human-only finding
+- [ ] Each closed finding has a static regression test that would have caught it
+- [ ] Reviewer response drafted for the **Resolution Center**; App Review Appeal (`https://developer.apple.com/contact/request/app-review/appeal/`) only considered if that exchange doesn't resolve it
+
 ## Final
 - [ ] Build version incremented vs last App Store version
+- [ ] All five pipeline states verified independently (build finished, submit processed, TestFlight Ready to Submit, build attached to version, Update Review) — not assumed from the first
 - [ ] Decision is GO or GO_WITH_WARNINGS (no open BLOCKER)

--- a/plugins/apple-store-release-agent/checklists/testflight-smoke.md
+++ b/plugins/apple-store-release-agent/checklists/testflight-smoke.md
@@ -10,6 +10,7 @@ Run on the TestFlight build before App Review. Mark each pass/fail.
 ## Cold Start
 - [ ] Cold start < ~3s on mid-range device
 - [ ] No crash on first launch
+- [ ] Cold-launched **5×** on this Release/TestFlight build specifically — a broken top-level import of a recently added native package crashes before the root component mounts and does not reproduce in Debug/dev-client
 - [ ] Splash → onboarding/home transitions smooth
 
 ## Auth
@@ -38,6 +39,7 @@ Run on the TestFlight build before App Review. Mark each pass/fail.
 - [ ] Delete account reachable
 - [ ] Deletion confirms and signs out
 - [ ] Re-signup creates fresh state
+- [ ] Destructive confirmation tested on a **physical iPad** — nested confirmation sheets (a second one fired from inside the first's `onConfirm`) race the dismiss animation and reproduce mainly there, not on iPhone
 
 ## Crash / Stability Review
 - [ ] No crashes observed across smoke run

--- a/plugins/apple-store-release-agent/scripts/validate-missing-handlers.mjs
+++ b/plugins/apple-store-release-agent/scripts/validate-missing-handlers.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// validate-missing-handlers.mjs — find interactive elements that signal
+// "button" to VoiceOver/the reviewer but have no handler, plus nested
+// confirmation-sheet calls that race each other's dismiss animation on iPad.
+// Zero deps, ESM, Node >= 18. Flags: --project --output --strict --json
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const project = resolve(args.project || process.cwd());
+const findings = [];
+const add = (severity, area, message, file, line) =>
+  findings.push({ severity, area, message, file, line });
+
+const WINDOW = 6;
+const TOUCHABLE_RE = /TouchableOpacity|Pressable/;
+const ROLE_RE = /accessibilityRole\s*=\s*["']button["']/;
+const PRESS_RE = /onPress\s*=/;
+const CONFIRM_RE = /confirmAction\s*\(/g;
+const SKIP = /[\\/](node_modules|\.git|dist|build|coverage)[\\/]/;
+const EXT = /\.tsx$/;
+
+let scanned = 0;
+let deadButtons = 0;
+let nestedConfirms = 0;
+
+(function walk(dir) {
+  let entries = [];
+  try { entries = readdirSync(dir); } catch { return; }
+  for (const e of entries) {
+    if (e === "node_modules" || e === ".git" || e === "dist" || e === "build") continue;
+    const p = join(dir, e);
+    let st; try { st = statSync(p); } catch { continue; }
+    if (SKIP.test(p)) continue;
+    if (st.isDirectory()) walk(p);
+    else if (EXT.test(e) && scanned < 2000) {
+      scanned++;
+      const text = readFileSync(p, "utf8");
+      const lines = text.split("\n");
+
+      // (a) dead interactive element: accessibilityRole="button" with no onPress
+      // in the surrounding block (mirrors: rg TouchableOpacity|Pressable -A6 | rg -B6 accessibilityRole | rg -v onPress)
+      for (let i = 0; i < lines.length; i++) {
+        if (!ROLE_RE.test(lines[i])) continue;
+        const start = Math.max(0, i - WINDOW);
+        const end = Math.min(lines.length, i + WINDOW + 1);
+        const block = lines.slice(start, end).join("\n");
+        if (TOUCHABLE_RE.test(block) && !PRESS_RE.test(block)) {
+          deadButtons++;
+          add(
+            "BLOCKER",
+            "dead-interactive-element",
+            `accessibilityRole="button" with no onPress in the surrounding ${WINDOW}-line window — signals interactive to VoiceOver and to App Review, does nothing when tapped.`,
+            p,
+            i + 1
+          );
+        }
+      }
+
+      // (b) nested confirmation sheets: 2+ confirmAction() calls in the same file
+      // race the first sheet's dismiss animation, mostly reproducing on iPad.
+      const confirmCount = (text.match(CONFIRM_RE) || []).length;
+      if (confirmCount >= 2) {
+        nestedConfirms++;
+        add(
+          "WARNING",
+          "nested-confirmation-sheet",
+          `${confirmCount} confirmAction() calls in one file — a second confirmation fired from inside the first's onConfirm can collide with the first sheet's dismiss animation (reproduces mainly on iPad). Use one confirmation at a time.`,
+          p,
+          null
+        );
+      }
+    }
+  }
+})(join(project, "src"));
+
+if (findings.length === 0) {
+  add("INFO", "missing-handlers", "No dead interactive elements or nested confirmation sheets found under src/.", null);
+}
+
+const decision = decide(findings);
+const report = render(findings, decision, project, deadButtons, nestedConfirms);
+if (args.output) {
+  const { writeFileSync } = await import("node:fs");
+  writeFileSync(resolve(args.output), report, "utf8");
+} else if (!args.json) console.log(report);
+if (args.json) console.log(JSON.stringify({ project, decision, findings }, null, 2));
+process.exit(decision === "NO_GO" ? 1 : 0);
+
+function parseArgs(argv) {
+  const a = {};
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--strict") a.strict = true;
+    else if (k === "--json") a.json = true;
+    else if (k === "--project") a.project = argv[++i];
+    else if (k === "--output") a.output = argv[++i];
+  }
+  return a;
+}
+function decide(list) {
+  if (list.some((f) => f.severity === "BLOCKER")) return "NO_GO";
+  if (list.some((f) => f.severity === "WARNING")) return "GO_WITH_WARNINGS";
+  return "GO";
+}
+function render(list, decision, project, deadButtons, nestedConfirms) {
+  const lines = [];
+  lines.push("# Missing Handler / Nested Confirmation Audit");
+  lines.push(`**Project:** ${project}`);
+  lines.push(`**Decision:** ${decision}`);
+  lines.push(`**Summary:** ${deadButtons} dead interactive element(s), ${nestedConfirms} file(s) with nested confirmAction() calls.`);
+  lines.push("");
+  lines.push("This is Guideline 2.1(a) territory: a reviewer tapping a styled, accessible-looking element that does nothing is an instant rejection. Smoke-test destructive actions on a physical iPad — nested-sheet races reproduce there more than on iPhone.");
+  lines.push("");
+  lines.push("| Severity | Area | Message | File:Line |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const f of list) lines.push(`| ${f.severity} | ${f.area} | ${f.message} | ${f.file || "-"}${f.line ? ":" + f.line : ""} |`);
+  if (!list.length) lines.push("| (none) | - | No findings. | - |");
+  return lines.join("\n");
+}

--- a/plugins/apple-store-release-agent/scripts/validate-static-native-imports.mjs
+++ b/plugins/apple-store-release-agent/scripts/validate-static-native-imports.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// validate-static-native-imports.mjs — flag native modules imported at top-of-file.
+// Root cause: requireNativeModule() runs at Metro import-time, before the root
+// component mounts, so a broken native link crashes on launch with no JS stack
+// trace and no boot-time try/catch ever seeing it. Zero deps, ESM, Node >= 18.
+// Flags: --project --output --strict --json
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const project = resolve(args.project || process.cwd());
+const findings = [];
+const add = (severity, area, message, file, line) =>
+  findings.push({ severity, area, message, file, line });
+
+// Matches a top-level `import ... from "expo-x"` or `const x = require("expo-x")`.
+// Deliberately excludes bare "react-native" (core) — only flags native *packages*.
+const RE = /^(?:import\s.+\sfrom\s+|.*=\s*require\()\s*['"](expo-[^'"]+|@expo\/[^'"]+|react-native-[^'"]+)['"]/;
+const SKIP = /[\\/](node_modules|\.git|dist|build|coverage)[\\/]/;
+const EXT = /\.(tsx|ts|jsx|js)$/;
+
+let scanned = 0;
+let hits = 0;
+(function walk(dir) {
+  let entries = [];
+  try { entries = readdirSync(dir); } catch { return; }
+  for (const e of entries) {
+    if (e === "node_modules" || e === ".git" || e === "dist" || e === "build") continue;
+    const p = join(dir, e);
+    let st; try { st = statSync(p); } catch { continue; }
+    if (SKIP.test(p)) continue;
+    if (st.isDirectory()) walk(p);
+    else if (EXT.test(e) && scanned < 2000) {
+      scanned++;
+      const lines = readFileSync(p, "utf8").split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const m = RE.exec(lines[i]);
+        if (m) {
+          hits++;
+          add(
+            args.strict ? "WARNING" : "INFO",
+            "static-native-import",
+            `Top-level import of native package "${m[1]}" — if this package was added recently, a broken native link crashes on launch before the root component mounts and before any boot-time try/catch runs. Move it behind a function-scoped dynamic import (\`await import(...)\`) or confirm it has been import-time-safe across at least one prior release.`,
+            p,
+            i + 1
+          );
+        }
+      }
+    }
+  }
+})(join(project, "src"));
+
+if (hits === 0) {
+  add("INFO", "static-native-import", "No top-level native-module imports found under src/.", null);
+}
+
+const decision = decide(findings);
+const report = render(findings, decision, project);
+if (args.output) {
+  const { writeFileSync } = await import("node:fs");
+  writeFileSync(resolve(args.output), report, "utf8");
+} else if (!args.json) console.log(report);
+if (args.json) console.log(JSON.stringify({ project, decision, findings }, null, 2));
+process.exit(decision === "NO_GO" ? 1 : 0);
+
+function parseArgs(argv) {
+  const a = {};
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--strict") a.strict = true;
+    else if (k === "--json") a.json = true;
+    else if (k === "--project") a.project = argv[++i];
+    else if (k === "--output") a.output = argv[++i];
+  }
+  return a;
+}
+function decide(list) {
+  if (list.some((f) => f.severity === "BLOCKER")) return "NO_GO";
+  if (list.some((f) => f.severity === "WARNING")) return "GO_WITH_WARNINGS";
+  return "GO";
+}
+function render(list, decision, project) {
+  const lines = [];
+  lines.push("# Static Native Import Audit");
+  lines.push(`**Project:** ${project}`);
+  lines.push(`**Decision:** ${decision}`);
+  lines.push("");
+  lines.push("This is a heuristic, not proof of a crash — confirm each hit against the package's actual add date and native-linking behavior. Cold-launch a Release build 5× regardless; this bug does not reproduce in Debug/dev-client builds.");
+  lines.push("");
+  lines.push("| Severity | Area | Message | File:Line |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const f of list) lines.push(`| ${f.severity} | ${f.area} | ${f.message} | ${f.file || "-"}${f.line ? ":" + f.line : ""} |`);
+  if (!list.length) lines.push("| (none) | - | No findings. | - |");
+  return lines.join("\n");
+}

--- a/plugins/google-play-release-agent/SKILL.md
+++ b/plugins/google-play-release-agent/SKILL.md
@@ -184,6 +184,8 @@ Treat as **HIGH** risk (forces NO_GO unless resolved):
 - Target SDK below the current Play requirement.
 - Mock mode left on in a release build.
 - `versionCode` not incremented (would block upload).
+- A recently added native package (`expo-*`/`react-native-*`) imported at top-of-file: Android has the same import-time native-module-init failure mode as iOS — a broken native link crashes on launch before the root component mounts, and it will not reproduce in a debug build. Cold-launch a release build 5× when a native dependency was added.
+- An `accessibilityRole="button"` element (or equivalent Android interactive role) with no press handler: same cross-platform bug as the iOS 2.1(a) dead-button rejection — a styled, accessible-looking element that does nothing fails review on either store.
 
 ## Presets
 

--- a/plugins/google-play-release-agent/checklists/google-play-review.md
+++ b/plugins/google-play-release-agent/checklists/google-play-review.md
@@ -17,6 +17,8 @@ Use before submitting. Every box must be checked for **GO**.
 
 ## Stability
 - [ ] No crashes on cold start
+- [ ] Cold-launched the release build 5× after adding any native package (`expo-*`/`react-native-*`) — a broken native link imported at top-of-file crashes before the root component mounts on Android too, and does not reproduce in a debug build (cross-platform with the iOS crash-on-launch pattern)
+- [ ] No interactive element (button, pressable) with a visible/accessible role and no press handler — same failure class as iOS's dead-button rejection
 - [ ] No ANRs on main flows
 - [ ] Pre-launch report reviewed (Roboto test)
 - [ ] Crashlytics / crash reporting configured

--- a/plugins/graph-feature-architect/SKILL.md
+++ b/plugins/graph-feature-architect/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: graph-feature-architect
+description: "Plan new feature implementations grounded in the project's existing knowledge graph (graphify-out/ or a karpathy-graph output) instead of ad-hoc grepping. Use when a graph already exists for the target codebase and the user wants to plan, scope, or architect a feature that plausibly touches more than one module — surfaces god nodes, community boundaries, and cross-file relationships before any code is written. If no graph exists yet, this skill says so and defers to building one (graphify update . or the karpathy-graph plugin) rather than guessing relationships."
+---
+
+# Graph Feature Architect
+
+Minimal skeleton, recreated after the original plugin was removed from the hub while consumer repos still symlinked to it. See `agents/graph-feature-architect.md` for the operating flow: locate the graph, scope the feature into 1-3 graph queries, rank blast radius, sequence the plan leaf-to-god-node, and report honestly when the graph is missing or stale.
+
+Use `karpathy-graph` first if no graph exists yet — this plugin only plans against a graph that is already built.

--- a/plugins/graph-feature-architect/agents/graph-feature-architect.md
+++ b/plugins/graph-feature-architect/agents/graph-feature-architect.md
@@ -1,0 +1,44 @@
+---
+name: graph-feature-architect
+description: Use this agent to scope and architect a new feature against an existing project knowledge graph (graphify-out/graph.json or a karpathy-graph output) instead of grepping the codebase cold. It queries the graph for god nodes, community boundaries, and cross-file relationships the feature would touch, then proposes an implementation plan that respects the discovered architecture and flags high-blast-radius nodes before code is written.
+Examples:
+<example>
+Context: The repo has a graphify-out/ graph and the user wants to add a feature that touches several modules.
+user: "plan how to add offline sync to the sync service without breaking the existing consumers"
+assistant: "graph-feature-architect runs `graphify query` / `graphify path` to find every module connected to the sync service, ranks them by blast radius, and returns an implementation plan that sequences changes from leaf nodes to god nodes."
+<commentary>Triggers when a feature plan needs to be grounded in real cross-file relationships rather than a manual grep sweep.</commentary>
+</example>
+<example>
+Context: No graph exists yet for the target codebase.
+user: "architect the new notifications feature using the graph"
+assistant: "graph-feature-architect checks for graphify-out/graph.json first; if absent, it says so and defers to building one (karpathy-graph) before planning, rather than guessing at relationships."
+<commentary>The agent never fabricates graph relationships — it fails closed and asks for a graph to be built first.</commentary>
+</example>
+tools: Read, Grep, Glob, Bash
+---
+
+# Graph Feature Architect
+
+Plans feature implementations by reading an existing project knowledge graph first, not by re-deriving architecture from scratch on every task.
+
+## When to use
+
+- A `graphify-out/graph.json` (this hub's convention) or a `karpathy-graph` output already exists for the target repo, **and**
+- The user wants to add, extend, or refactor a feature that plausibly touches more than one module.
+
+## When NOT to use
+
+- No graph exists yet. Say so explicitly and point at building one (`graphify update .` or the `karpathy-graph` plugin) instead of guessing relationships from memory or a quick grep.
+- The task is a single-file, single-responsibility change — plain reading is faster and this agent adds no value.
+
+## Operating flow
+
+1. **Locate the graph.** Prefer `graphify-out/graph.json` if present; otherwise look for a `karpathy-graph` output directory (`.karpathy-graphs/<name>/graph.json`). If neither exists, stop and report that no graph was found.
+2. **Scope the feature.** Turn the feature request into 1-3 graph queries: `graphify query "<question>"`, `graphify path "<A>" "<B>"` for how two areas connect, `graphify explain "<concept>"` for a focused subgraph.
+3. **Rank blast radius.** Nodes with many inbound edges (god nodes) or that sit on a community boundary are higher risk to touch — call them out explicitly, do not bury them in a list.
+4. **Sequence the plan.** Order proposed changes from leaf nodes (few dependents) toward god nodes (many dependents), so early steps are cheap to revert if the design is wrong.
+5. **Report gaps honestly.** If the graph is stale (older than the latest relevant commits) or does not cover the area in question, say so instead of treating a partial subgraph as complete coverage.
+
+## Output
+
+A short implementation plan: affected nodes (file/module), why each is affected (the graph edge that connects it to the feature), risk tier (leaf / mid / god node), and a suggested change order. Not a full PRD, not a code diff — the plan a human or another agent uses to start implementing safely.

--- a/plugins/graph-feature-architect/plugin.json
+++ b/plugins/graph-feature-architect/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "graph-feature-architect",
+  "version": "1.0.0",
+  "description": "Plan new feature implementations grounded in the project's existing knowledge graph (graphify-out/ or a karpathy-graph output) instead of ad-hoc grepping. Use when the user asks to plan, scope, or architect a new feature and a graph already exists for the codebase — surfaces god nodes, community boundaries, and cross-file relationships the feature will touch before any code is written. Recreated as a minimal skeleton after the original plugin was removed from the hub; broken symlinks in consumer repos pointed here.",
+  "author": {
+    "name": "Anderson Lima",
+    "url": "https://andersonlimahw.github.io"
+  },
+  "license": "MIT",
+  "keywords": [
+    "skill",
+    "lemon-ai-hub",
+    "graph-feature-architect",
+    "knowledge-graph",
+    "feature-planning",
+    "architecture",
+    "graphify"
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes product-specific Apple/Google Play rejection learnings (5 real App Store rejections, Jul–Sep 2026, root-caused and approved) into the hub's cross-platform release/review plugins. Nothing product-specific (App ID, screen names, internal rule numbers) — every learning was translated to a generic, reusable pattern.

- **`app-store-review`** — second round of field-observed rejection patterns in `references/field-lessons-rn-expo.md` + `SKILL.md`:
  - Crash on launch from an import-time native module (`requireNativeModule` runs before the root component mounts; no JS stack trace, no boot-guard catches it)
  - Orphan routes reappearing a closed bug class (registered but unlinked routes are still reachable)
  - 2.3.10 rejections that are actually an App Store Connect IAP localization field, not app code
  - Investigation methodology: audit current code before acting on rejection text, split PLAN (code-provable) vs HUMAN (device/ASC UI/agreements), one static regression test per closed finding
  - Fifth release-pipeline state (`TestFlight Ready to Submit`, previously missing)
  - Official Apple contact channels (Resolution Center, App Review Appeal, Developer Support)

- **`apple-store-release-agent`** — two new executable validators plus matching checklist/SKILL.md gates:
  - `validate-static-native-imports.mjs` — flags a native package imported at top-of-file (heuristic INFO/WARNING)
  - `validate-missing-handlers.mjs` — flags `accessibilityRole="button"` with no `onPress` (BLOCKER) and nested `confirmAction()` calls that race the dismiss animation on iPad (WARNING)
  - New "Rejection Response Discipline" section in `checklists/apple-review.md`; cold-launch/nested-sheet gates in `checklists/testflight-smoke.md`

- **`app-store-connect-api`** — explicit "what the API can and cannot do" table in `SKILL.md`: reads, Age Rating / IAP localization patches, promo-image 3-step upload, and the confirmed hard-nos (`diagnosticSignatures` returns empty for reviewer-attached crash logs, Resolution Center is UI-only, sandbox tester creation is UI-only). Marked to re-check against Apple's current API reference — volatile surface.

- **`google-play-release-agent`** — cross-platform crossover: the crash-on-launch (static native import) and dead-handler (missing press handler) patterns apply to Android too; added to `SKILL.md` high-risk criteria and `checklists/google-play-review.md` Stability section.

- **`graph-feature-architect`** — recreated as a minimal plugin (`plugin.json`, `SKILL.md`, one agent) after discovering it had been removed from the hub while a consumer repo (`vaiterfut-mobile-app`) still had a symlink pointing at it (`.claude/agents/graph-feature-architect.md`, now resolves). Scoped to what the name promises: planning a feature against an existing project knowledge graph (`graphify-out/` or `karpathy-graph` output). Registered in `marketplace.json`.

## Test plan

- [x] Both new validator scripts smoke-tested against a fixture file (dead button, nested `confirmAction`, top-level native import) — correct BLOCKER/WARNING/INFO output in both text and `--json` mode, and a clean-project case with zero findings
- [x] `claude plugin validate` passed for all 5 touched/created plugin manifests
- [x] `python3 scripts/validate_plugins.py` — 0 new errors/warnings introduced (1 pre-existing unrelated error: `heygen-expert` missing from marketplace)
- [x] `bash scripts/harness-doctor.sh` — 30 OK / 0 FAIL / 7 WARN (all 7 warnings pre-existing, unrelated to this change — duplicated skills under `~/.claude/skills`)
- [x] Confirmed the previously-broken symlink in `vaiterfut-mobile-app/.claude/agents/graph-feature-architect.md` now resolves
- [x] Diff scanned for secrets/`.p8` — none found (only guidance text referencing the `*.p8` gitignore pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)